### PR TITLE
fix: resolve datacenters not loading due to wrong filename and field

### DIFF
--- a/backend/services/data_fetcher.py
+++ b/backend/services/data_fetcher.py
@@ -1691,7 +1691,7 @@ def fetch_internet_outages():
     if outages:
         _mark_fresh("internet_outages")
 
-_DC_GEOCODED_PATH = Path(__file__).parent.parent / "data" / "datacenters_geocoded.json"
+_DC_GEOCODED_PATH = Path(__file__).parent.parent / "data" / "datacenters.json"
 
 
 def fetch_datacenters():
@@ -1703,8 +1703,9 @@ def fetch_datacenters():
             return
         raw = json.loads(_DC_GEOCODED_PATH.read_text(encoding="utf-8"))
         for entry in raw:
-            lat = entry.get("lat")
-            lng = entry.get("lng")
+            coords = entry.get("city_coords") or [entry.get("lat"), entry.get("lng")]
+            lat = coords[0] if coords else None
+            lng = coords[1] if coords else None
             if lat is None or lng is None:
                 continue
             if not (-90 <= lat <= 90 and -180 <= lng <= 180):


### PR DESCRIPTION
Issue #55 : Data centers are not rendering on the map. The backend returns an empty datacenters array despite the data file being present.

Root cause: Two mismatches between the code and the actual data file:
1. Code looks for datacenters_geocoded.json — file on disk is datacenters.json
2. Code reads lat/lng fields directly — file stores coordinates as city_coords: [lat, lng]

Both issues cause fetch_datacenters() to silently return 0 entries.