### PR TITLE
Adds makefile-based taskrunner with lan or local-only access options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.PHONY: up-local up-lan down restart-local restart-lan logs status help
+
+COMPOSE = docker compose
+
+# Detect LAN IP (tries Wi-Fi first, falls back to Ethernet)
+LAN_IP := $(shell ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)
+
+## Default target — print help
+help:
+	@echo ""
+	@echo "Shadowbroker taskrunner"
+	@echo ""
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "  up-local        Start with loopback binding (local access only)"
+	@echo "  up-lan          Start with 0.0.0.0 binding (LAN accessible)"
+	@echo "  down            Stop all containers"
+	@echo "  restart-local   Bounce and restart in local mode"
+	@echo "  restart-lan     Bounce and restart in LAN mode"
+	@echo "  logs            Tail logs for all services"
+	@echo "  status          Show container status"
+	@echo ""
+
+## Start in local-only mode (loopback only)
+up-local:
+	BIND=127.0.0.1 $(COMPOSE) up -d
+
+## Start in LAN mode (accessible to other hosts on the network)
+up-lan:
+	@if [ -z "$(LAN_IP)" ]; then \
+		echo "ERROR: Could not detect LAN IP. Check your network connection."; \
+		exit 1; \
+	fi
+	@echo "Detected LAN IP: $(LAN_IP)"
+	BIND=0.0.0.0 CORS_ORIGINS=http://$(LAN_IP):3000 $(COMPOSE) up -d
+	@echo ""
+	@echo "Shadowbroker is now running and can be accessed by LAN devices at http://$(LAN_IP):3000"
+
+## Stop all containers
+down:
+	$(COMPOSE) down
+
+## Restart in local-only mode
+restart-local: down up-local
+
+## Restart in LAN mode
+restart-lan: down up-lan
+
+## Tail logs for all services
+logs:
+	$(COMPOSE) logs -f
+
+## Show running container status
+status:
+	$(COMPOSE) ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./backend
     container_name: shadowbroker-backend
     ports:
-      - "8000:8000"
+      - "${BIND:-127.0.0.1}:8000:8000"
     environment:
       - AIS_API_KEY=${AIS_API_KEY}
       - OPENSKY_CLIENT_ID=${OPENSKY_CLIENT_ID}
@@ -32,7 +32,7 @@ services:
       context: ./frontend
     container_name: shadowbroker-frontend
     ports:
-      - "3000:3000"
+      - "${BIND:-127.0.0.1}:3000:3000"
     environment:
       # Points the Next.js server-side proxy at the backend container via Docker networking.
       # Change this if your backend runs on a different host or port.


### PR DESCRIPTION
Adds ability to quickly toggle between running local-only and LAN-accessible instances using make commands. Includes additional commands for stopping/restarting instances, tailing logs, and checking container status.

This includes a slight modification to the backend & frontend port binding configurations in docker-compose.yml:
  - sets local-access only port bindings by default (127.0.0.1)
  - allows port-binding address override using BIND env variable (0.0.0.0 for LAN)

When running make command to spin up LAN-accessible instance, CORS_ORIGINS is dynamically set to the local IP address.

Preview:
<img width="1302" height="486" alt="makefile-local-lan-taskrunner" src="https://github.com/user-attachments/assets/10708061-db71-4213-8d34-3091b61dab46" />
