### PR TITLE
fix: skip Secure cookie flag for admin session on localhost

### DIFF
--- a/frontend/src/app/api/admin/session/route.ts
+++ b/frontend/src/app/api/admin/session/route.ts
@@ -12,11 +12,17 @@ const NO_STORE_HEADERS = {
   Pragma: 'no-cache',
 };
 
-function cookieOptions() {
+function isLoopback(req: NextRequest): boolean {
+  const host = req.headers.get('host') || '';
+  const hostname = host.split(':')[0];
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function cookieOptions(req: NextRequest) {
   return {
     httpOnly: true,
     sameSite: 'strict' as const,
-    secure: process.env.NODE_ENV === 'production',
+    secure: process.env.NODE_ENV === 'production' && !isLoopback(req),
     path: '/',
     maxAge: COOKIE_MAX_AGE,
   };
@@ -80,7 +86,7 @@ export async function POST(req: NextRequest) {
   }
   const sessionToken = createAdminSessionToken(adminKey, COOKIE_MAX_AGE);
   const res = NextResponse.json({ ok: true }, { headers: NO_STORE_HEADERS });
-  res.cookies.set(COOKIE_NAME, sessionToken, cookieOptions());
+  res.cookies.set(COOKIE_NAME, sessionToken, cookieOptions(req));
   return res;
 }
 
@@ -91,7 +97,7 @@ export async function DELETE(req: NextRequest) {
   }
   const res = NextResponse.json({ ok: true }, { headers: NO_STORE_HEADERS });
   res.cookies.set(COOKIE_NAME, '', {
-    ...cookieOptions(),
+    ...cookieOptions(req),
     maxAge: 0,
   });
   return res;


### PR DESCRIPTION
## Summary

Fixes #129 — the admin session cookie's `Secure` flag prevents it from being sent over plain HTTP on localhost, making the API Keys panel (and other admin-gated settings) inaccessible for self-hosted users.

- Adds an `isLoopback()` helper that checks if the request's `Host` header is `localhost`, `127.0.0.1`, or `::1`
- Passes the request to `cookieOptions()` so it can skip the `Secure` flag on loopback
- Non-localhost deployments (including LAN IP and domain-based access) are unaffected — `Secure` is still set in production

## Test plan

- [x] Built local frontend Docker image with the fix
- [x] Verified cookie **no longer** has `Secure` flag on `http://localhost:3000`
- [x] Verified API Keys tab populates after UNLOCK on localhost
- [x] Verify cookie **still has** `Secure` flag when accessed via non-loopback hostname