### PR TITLE
test: stabilize v0.9.7 post-merge CI

### DIFF
--- a/frontend/src/__tests__/mesh/messagesViewFirstContact.test.tsx
+++ b/frontend/src/__tests__/mesh/messagesViewFirstContact.test.tsx
@@ -302,7 +302,7 @@ describe('MessagesView first-contact trust UX', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Send Secure Mail' }));
 
-    await screen.findByText(/Mail delivered to Pinned Peer/i);
+    await screen.findByText(/Mail delivered to Pinned Peer/i, {}, { timeout: 5000 });
     expect(mocks.prepareWormholeInteractiveLane).toHaveBeenCalled();
     expect(mocks.sendDmMessage).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- give the secure-mail warmup assertion enough time on GitHub's busy Linux runner
- no production code changes

## Verification
- npx vitest run src/__tests__/mesh/messagesViewFirstContact.test.tsx --reporter=verbose
- npx vitest run --reporter=verbose
- npm run build