### PR TITLE
Helm chart: switch image registry from GitLab to GHCR

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -13,8 +13,9 @@ shadowbroker:
             runAsGroup: 1001
           image:
             pullPolicy: Always
-            # GitLab (primary) | GitHub (mirror): ghcr.io/bigbodycobain/shadowbroker-backend
-            repository: registry.gitlab.com/bigbodycobain/shadowbroker/backend
+            # GHCR (primary, public, auto-built on every push to main).
+            # GitLab fallback: registry.gitlab.com/bigbodycobain/shadowbroker/backend (requires auth + currently no CI builds it).
+            repository: ghcr.io/bigbodycobain/shadowbroker-backend
             tag: latest
           env:
             AIS_API_KEY:
@@ -42,8 +43,9 @@ shadowbroker:
             runAsGroup: 1001
           image:
             pullPolicy: Always
-            # GitLab (primary) | GitHub (mirror): ghcr.io/bigbodycobain/shadowbroker-frontend
-            repository: registry.gitlab.com/bigbodycobain/shadowbroker/frontend
+            # GHCR (primary, public, auto-built on every push to main).
+            # GitLab fallback: registry.gitlab.com/bigbodycobain/shadowbroker/frontend (requires auth + currently no CI builds it).
+            repository: ghcr.io/bigbodycobain/shadowbroker-frontend
             tag: latest
 
           env:


### PR DESCRIPTION
## Summary

Brings the Helm chart's install path to parity with `docker-compose.yml` by switching the default image registry from GitLab to GHCR.

## Why

The chart referenced `registry.gitlab.com/bigbodycobain/shadowbroker/{backend,frontend}:latest` as the primary image source, but for new Kubernetes installs that path is effectively broken:

| Issue | Impact |
|---|---|
| **No `.gitlab-ci.yml` exists** in this repo (and never has, per `git log --all -- .gitlab-ci.yml`) | GitLab registry is never populated by automated builds — any images there would be stale or manually pushed |
| **GitLab registry returns HTTP 401** on anonymous pulls | Even if images existed, Helm-managed deployments without registry credentials would fail |
| `docker-compose.yml` already uses GHCR as primary | Helm and Compose installs were diverging silently |

GHCR is built and pushed on every merge to `main` by `.github/workflows/docker-publish.yml`, and `ghcr.io` allows anonymous pulls for public images. Switching makes K8s installs match what Docker Compose users have been getting since the workflow was set up.

## What changes

```diff
- repository: registry.gitlab.com/bigbodycobain/shadowbroker/backend
+ repository: ghcr.io/bigbodycobain/shadowbroker-backend

- repository: registry.gitlab.com/bigbodycobain/shadowbroker/frontend
+ repository: ghcr.io/bigbodycobain/shadowbroker-frontend
```

GitLab is preserved in the comments as a documented fallback for operators who run private mirrors with their own CI.

## Validation
- `python -c "import yaml; yaml.safe_load(open('helm/chart/values.yaml'))"` — parses cleanly
- `python -c "import yaml; yaml.safe_load(open('helm/chart/Chart.yaml'))"` — parses cleanly
- Verified GHCR has the correct `:latest` tags published (built from main `421682c`, includes #227, #232, #235)

## Effect on running deployments
- **New `helm install`** → now pulls the correct, current images. Previously would have either errored on 401 or pulled stale GitLab images.
- **Existing `helm upgrade`** → forces a re-pull from the new registry. Since `tag: latest` and `pullPolicy: Always` are unchanged, the only visible difference to an existing deployment is the image origin. Both registries (in principle) ship the same artifact, but GHCR is the one we actually publish to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
