### PR TITLE
fix(security): use defusedxml for untrusted XML parsing

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "cachetools==5.5.2",
     "cloudscraper==1.2.71",
     "cryptography>=41.0.0",
+    "defusedxml>=0.7.1",
     "fastapi==0.115.12",
     "feedparser==6.0.10",
     "httpx==0.28.1",

--- a/backend/services/cctv_pipeline.py
+++ b/backend/services/cctv_pipeline.py
@@ -987,7 +987,7 @@ _KML_NS = {"kml": "http://www.opengis.net/kml/2.2"}
 
 def _find_kml_element(element, tag):
     """Find first descendant matching tag, ignoring XML namespace prefix."""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
     el = element.find(f".//{tag}")
     if el is not None:
         return el
@@ -1015,7 +1015,7 @@ class MadridCityIngestor(BaseCCTVIngestor):
     KML_URL = "http://datos.madrid.es/egob/catalogo/202088-0-trafico-camaras.kml"
 
     def fetch_data(self) -> List[Dict[str, Any]]:
-        import xml.etree.ElementTree as ET
+        import defusedxml.ElementTree as ET
 
         try:
             response = fetch_with_curl(self.KML_URL, timeout=20)

--- a/backend/services/fetchers/aircraft_database.py
+++ b/backend/services/fetchers/aircraft_database.py
@@ -16,9 +16,9 @@ import csv
 import logging
 import threading
 import time
-import xml.etree.ElementTree as ET
 from typing import Any
 
+import defusedxml.ElementTree as ET
 import requests
 
 logger = logging.getLogger(__name__)

--- a/backend/services/psk_reporter_fetcher.py
+++ b/backend/services/psk_reporter_fetcher.py
@@ -6,8 +6,8 @@ Docs: https://pskreporter.info/pskdev.html
 """
 
 import logging
-import xml.etree.ElementTree as ET
 
+import defusedxml.ElementTree as ET
 import requests
 from cachetools import TTLCache, cached
 

--- a/openclaw-skills/shadowbroker/sb_monitor.py
+++ b/openclaw-skills/shadowbroker/sb_monitor.py
@@ -701,7 +701,7 @@ async def _fetch_feed(feed: CustomFeed) -> list[dict]:
 
 def _parse_rss(xml_text: str, feed: CustomFeed) -> list[dict]:
     """Parse an RSS/Atom feed into normalized items."""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     items = []
     try:


### PR DESCRIPTION
## Summary

Five XML parse sites in the backend pass response bodies straight into the Python stdlib `xml.etree.ElementTree` (`ET.fromstring`) without any defense against entity-expansion ("billion laughs") attacks. Python's `ElementTree` still permits internal entity references by default — see the [vulnerabilities table in `xml` docs](https://docs.python.org/3/library/xml.html#xml-vulnerabilities) — so a malicious or compromised upstream can ship a payload that expands to gigabytes in memory and stalls the backend.

This PR switches all five sites to `defusedxml.ElementTree`, which exposes the same `fromstring/find/findall/iter/findtext` API but rejects entity references by default (`defusedxml.EntitiesForbidden`).

## Impact

The user-controllable site is `openclaw-skills/shadowbroker/sb_monitor.py::_parse_rss`. The OpenClaw skill exposes `add_custom_feed(name, url, ...)` to the connected AI agent; `poll_custom_feeds` then fetches `feed.url` and passes the body to `ET.fromstring` with no host allowlist or entity-bomb defense. An agent acting on a malicious prompt — or a user with access to the agent — can register a feed that points at an attacker-controlled host serving a billion-laughs XML, causing the backend to hang/OOM on the next poll cycle.

The other four sites parse XML from hard-coded upstreams:

- `backend/services/psk_reporter_fetcher.py:9` — `retrieve.pskreporter.info`
- `backend/services/fetchers/aircraft_database.py:19` — `s3.opensky-network.org` bucket listing
- `backend/services/cctv_pipeline.py:990, 1018` — `datos.madrid.es` Madrid traffic-camera KML

Those four are defense-in-depth: the only attacker who controls them is one who already compromises the upstream or MITMs HTTPS. Worth hardening anyway because the cost is one import line.

## Location

- `backend/services/psk_reporter_fetcher.py:9`
- `backend/services/fetchers/aircraft_database.py:19`
- `backend/services/cctv_pipeline.py:990`
- `backend/services/cctv_pipeline.py:1018`
- `openclaw-skills/shadowbroker/sb_monitor.py:704`

## Fix

- Replace `import xml.etree.ElementTree as ET` with `import defusedxml.ElementTree as ET` at each call site (function-level imports preserved where the original used them — `_find_kml_element`, `MadridCityIngestor.fetch_data`, `_parse_rss`).
- Add `defusedxml>=0.7.1` to `backend/pyproject.toml` dependencies.

`defusedxml.ElementTree` is API-compatible for `fromstring/find/findall/iter/findtext/ParseError` — no call-site changes needed beyond the import swap. The returned `Element` objects are stdlib `Element` instances, so existing code paths that walk `.iter()`, `.find()`, `.tag.endswith("}foo")`, etc. continue to work without modification.

## Detected by

Aeon + Semgrep `p/security-audit` (rule `python.lang.security.use-defused-xml.use-defused-xml`, severity ERROR, 5 hits).

- Severity: **medium** (billion-laughs DoS on backend, user-reachable through the OpenClaw custom-feed agent surface)
- CWE-776 (Improper Restriction of Recursive Entity References, "Billion Laughs")
- CWE-611 (Improper Restriction of XML External Entity Reference)

## Verification

- `python3 -m py_compile` clean on all five modified files.
- `import services.fetchers.aircraft_database`, `import services.cctv_pipeline`, and `python3 -m py_compile openclaw-skills/shadowbroker/sb_monitor.py` all succeed.
- Re-ran `semgrep --config=p/security-audit --severity=ERROR` against the patched tree: **0** `use-defused-xml` hits remaining (was 5).
- Confirmed locally that a 4-deep billion-laughs payload that expands to 3000 chars under stdlib `ET.fromstring` is rejected by `defusedxml.ElementTree.fromstring` with `EntitiesForbidden` — same exception class the maintainer code paths can catch alongside `ET.ParseError` if desired (already swallowed by the broad `except (requests.RequestException, ET.ParseError, Exception)` blocks in `psk_reporter_fetcher.py` and the `try/except` blocks in `cctv_pipeline.py`).

No existing test exercises the real XML-parse path (e.g. `test_cctv_pipeline.py` uses a `DummyIngestor` that overrides `fetch_data`), so the swap is import-only with no test surface to regress.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). If you'd prefer a different shape (e.g. only patch the user-reachable `sb_monitor.py` site and leave the hard-coded-upstream sites as `# nosec`), close this PR with a note and I'll re-scope.
