### PR TITLE
test(ci): raise vitest testTimeout to 15s to stop CI-load flakes

### DIFF
--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -6,6 +6,35 @@ module.exports = defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
+    // Default test timeout: 15s (up from vitest's 5s default).
+    //
+    // We render real React component trees under jsdom in many tests, and
+    // GitHub Actions' shared Node.js workers (specifically the
+    // "CI - Lint & Test / Frontend Tests & Build" job) consistently
+    // measure 6–10s for the heavier MessagesView / GateView / Wormhole
+    // contact flows under CI load. On a developer laptop those same tests
+    // settle in <1s, so the 5s default was tuned to local dev speed and
+    // not to CI runner speed.
+    //
+    // Concrete history that drove this bump (none of these were real
+    // product bugs — all were CI load racing the 5s ceiling on
+    // findByText / waitFor against React reconciliation):
+    //   PR #226, #237, #261, #262, #265 all flaked on
+    //     src/__tests__/mesh/messagesViewFirstContact.test.tsx
+    //     src/__tests__/mesh/gateCompatDecryptUx.test.tsx
+    //   PR #262's flake was the worst — it fired on the post-merge
+    //   Docker Publish run and prevented the AIS SPKI security fix's
+    //   image from being published to GHCR until the next PR
+    //   cumulatively re-published it.
+    //
+    // 15s is generous enough to absorb routine CI slowness without
+    // masking real "test never settles" bugs (those would still time
+    // out, just three rounds later). Individual tests can still pin
+    // their own tighter timeout via the third arg to `it()`.
+    testTimeout: 15000,
+    // Hook timeout follows test timeout — beforeEach/afterEach setup
+    // for the heavier component tests has the same CI-load sensitivity.
+    hookTimeout: 15000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Raises vitest's per-test timeout from 5s (default) to 15s suite-wide. This is a **CI pipeline reliability fix** — no behavioral change for end users, no security fix, no feature work.

## Why this matters

The same class of CI-load-sensitive flake has bit us 5 times in 2 days:

| PR | Test that flaked |
|---|---|
| #226 | `messagesViewFirstContact > removes an approved contact` |
| #237 | (same) |
| #261 | (same) |
| **#262** | (same) — **fired on the POST-MERGE Docker Publish run, prevented the AIS SPKI security fix from being published** until PR #263 cumulatively re-published it. Real shipping-of-security-fixes risk. |
| #264 | Deflaked that ONE specific test surgically |
| **#265** | `messagesViewFirstContact > legacy handle-only` AND `gateCompatDecryptUx > browser-local gate runtime` (both new timeouts), plus failed on **rerun too** — confirming the flake class is broader than the one test PR #264 fixed |

The PR #264 fix was correct but too surgical. Multiple other React component tests have the same fundamental shape — render a component tree under jsdom, click a button, wait for an async state-update-and-paint to complete — and they all hit the same 5s ceiling under CI load.

## The fix

```js
// vitest.config.js
testTimeout: 15000,
hookTimeout: 15000,
```

That's it. 15s is **3× the default** — enough headroom for routine CI slowness, not enough to mask real "test never settles" bugs.

## What this does NOT do

- ❌ Does not slow down healthy tests. Tests that pass in 100ms still pass in 100ms.
- ❌ Does not change any test logic.
- ❌ Does not affect end users in any way.
- ❌ Does not delay real failures — a deadlocked test now takes 15s to declare failure instead of 5s, which is negligible in a suite that runs once per CI invocation.

## What this DOES do

- ✅ Eliminates the entire class of "CI-load racing the test timeout" flakes.
- ✅ Stops post-merge Docker Publish runs from getting blocked by these flakes (which is the actual security-fix-shipping risk that bit PR #262).
- ✅ Removes the manual "rerun CI when it flakes" toil that's been costing time on every recent PR.

Individual tests can still pin their own tighter timeout via the third arg to `it()` if a specific test SHOULD fail fast.

## Validation

```
Local full vitest run → 707 passed, 72 files, 10.36s wall clock
```

Same wall-clock time as before — we only changed how long we **wait** for slow tests, not how fast tests actually run.

## Sequencing

After this lands, I'll retrigger CI on PR #265 (#231 supply-chain fix). It should pass cleanly under the new timeout, then merge normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
