### PR TITLE
Fix #279: add defusedxml to uv.lock so Docker image installs it

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -82,6 +82,7 @@ dependencies = [
     { name = "cachetools" },
     { name = "cloudscraper" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "feedparser" },
     { name = "httpx" },
@@ -120,6 +121,7 @@ requires-dist = [
     { name = "cachetools", specifier = "==5.5.2" },
     { name = "cloudscraper", specifier = "==1.2.71" },
     { name = "cryptography", specifier = ">=41.0.0" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "fastapi", specifier = "==0.115.12" },
     { name = "feedparser", specifier = "==6.0.10" },
     { name = "httpx", specifier = "==0.28.1" },
@@ -598,6 +600,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/53/916c2bbb6601108f694b7c37c71c650ef8d06c2ed282a704b5c8cca67edf/dbus_fast-4.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffc16ee344e68a907a40327074bca736086897f2e783541086eedb5e6855f3f0", size = 1610347, upload-time = "2026-02-01T21:05:43.086Z" },
     { url = "https://files.pythonhosted.org/packages/ad/f6/05eeb374a02f63b0e29b1ee2073569e8cf42f655970a651f938bcdbe7eae/dbus_fast-4.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1f8f4b0f8af730c39bbb83de1e299e706fbd7f7f3955764471213b013fa59516", size = 1549395, upload-time = "2026-02-01T21:05:45.159Z" },
     { url = "https://files.pythonhosted.org/packages/a4/87/d03a718e7bfdbbebaa4b6a66ba5bb069bc00a84e5ad176d8198cc785cd42/dbus_fast-4.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6af190d8306f1bd506740c39701f5c211aa31ac660a3fcb401ebb97d33166c7", size = 1627620, upload-time = "2026-02-01T21:05:46.878Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #279.

`defusedxml>=0.7.1` was declared in `backend/pyproject.toml` (line 18) but was **missing from `uv.lock`**. The backend Dockerfile installs Python deps via `uv sync --frozen --no-dev`, which only installs what's pinned in the lockfile — so the runtime image shipped without `defusedxml`, and the backend crashed on startup as soon as any import path touched it.

```
ModuleNotFoundError: No module named 'defusedxml'
```

## Affected import sites

- `backend/services/psk_reporter_fetcher.py:10`
- `backend/services/fetchers/aircraft_database.py:21`
- `backend/services/cctv_pipeline.py:990`
- `backend/services/cctv_pipeline.py:1018`

## Fix

Regenerated `uv.lock` with `uv lock`. Result:

```
Resolved 114 packages in 696ms
Added defusedxml v0.7.1
```

No code changes — only the lockfile. The next image build picks it up via the existing `uv sync --frozen` step.

## Test plan

- [x] `grep defusedxml uv.lock` now finds the entry (was missing on `main`).
- [x] Resolved version `0.7.1` matches the `>=0.7.1` specifier in `pyproject.toml`.
- [ ] Next GHCR Docker image build (auto-triggered by merge to `main`) must show `Installed defusedxml==0.7.1` in the `uv sync` log.
- [ ] Backend container starts without the `ModuleNotFoundError`.
