### PR TITLE
Fix #296: reject backend venvs missing uvicorn before launch (Windows)

### DIFF
--- a/start-backend.js
+++ b/start-backend.js
@@ -76,6 +76,13 @@ function canRun(command, args) {
   return !result.error && result.status === 0;
 }
 
+function canRunBackendPython(pythonBin) {
+  return (
+    canRun(pythonBin, ["-V"]) &&
+    canRun(pythonBin, ["-c", "import fastapi, uvicorn"])
+  );
+}
+
 function findBasePython() {
   const candidates = isWindows
     ? [
@@ -135,12 +142,12 @@ function rebuildBackendVenv(targetDir, basePython) {
   if (result.error || result.status !== 0) {
     return null;
   }
-  return canRun(repairedBin, ["-V"]) ? repairedBin : null;
+  return canRunBackendPython(repairedBin) ? repairedBin : null;
 }
 
 function ensureBackendVenv() {
   for (const candidate of venvCandidates) {
-    if (fs.existsSync(candidate) && canRun(candidate, ["-V"])) {
+    if (fs.existsSync(candidate) && canRunBackendPython(candidate)) {
       persistSelectedVenv(candidate);
       return candidate;
     }


### PR DESCRIPTION
Closes #296 (reported by @f3n3k on the Windows native install path).

## The error

```
[*] Starting backend with: C:\001\backend\venv\Scripts\python.exe -m uvicorn main:app
C:\001\backend\venv\Scripts\python.exe: No module named uvicorn
[backend] exited with 1

ShadowBroker has stopped. Exit code: 1
```

## Call chain that hits it

```
Start.bat
  └─ scripts\run-windows-runtime.ps1
       └─ frontend\scripts\dev-all.cjs
            └─ start-backend.js
                 └─ backend\venv\Scripts\python.exe -m uvicorn main:app
```

## Root cause

`start-backend.js` decided whether an existing `backend\venv` was usable by calling `canRun(candidate, ["-V"])`. That only checks whether Python itself can run — it does **not** check whether the backend's actual runtime dependencies are installed.

When the venv exists but `pip install -r requirements.txt` never finished (partial install, failed network, interrupted bootstrap, etc.), the launcher accepted that broken venv, then died with the exact error f3n3k reported.

## Fix

New `canRunBackendPython()` helper that requires **both**:

```js
canRun(pythonBin, ["-V"])                                    // Python is runnable
&& canRun(pythonBin, ["-c", "import fastapi, uvicorn"])      // backend deps installed
```

Used in two call sites:

- **`ensureBackendVenv()`** — when iterating candidate venvs on first launch, reject any venv whose Python can't import the backend's real entry-point deps. The launcher then falls through to its existing rebuild path (`rebuildBackendVenv`), which reinstalls deps before declaring the venv healthy.
- **`rebuildBackendVenv()`** — after a rebuild attempt, verify deps are present before returning the new interpreter path. Catches silent partial rebuilds.

The check IS the import that uvicorn itself would do at startup, so a green return here genuinely means "uvicorn will start". Cost is one extra `python -c` per venv candidate on launcher startup — milliseconds.

## Diff (full)

```diff
+function canRunBackendPython(pythonBin) {
+  return (
+    canRun(pythonBin, ["-V"]) &&
+    canRun(pythonBin, ["-c", "import fastapi, uvicorn"])
+  );
+}

   if (result.error || result.status !== 0) {
     return null;
   }
-  return canRun(repairedBin, ["-V"]) ? repairedBin : null;
+  return canRunBackendPython(repairedBin) ? repairedBin : null;
 }

 function ensureBackendVenv() {
   for (const candidate of venvCandidates) {
-    if (fs.existsSync(candidate) && canRun(candidate, ["-V"])) {
+    if (fs.existsSync(candidate) && canRunBackendPython(candidate)) {
       persistSelectedVenv(candidate);
       return candidate;
     }
```

## Test plan

- [x] `node --check start-backend.js` — syntax valid
- [ ] Manual Windows smoke test (operator with a half-baked `backend\venv`): the launcher should now rebuild instead of failing with `No module named uvicorn`

No unit tests added — `start-backend.js` is an operator-side launcher that shells out to filesystem and process APIs; mocking that would dwarf the 9-line fix.

## Provenance

The fix was originally drafted by another AI assistant working in the maintainer's local worktree but never committed or pushed. The change has been sitting uncommitted in the working tree alongside other in-progress work. This PR brings ONLY the `start-backend.js` change to GitHub (other working-tree changes are untouched and remain the maintainer's to commit when ready).

Credit: @f3n3k for the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
