### PR TITLE
fix(desktop-build): strip layout.tsx force-dynamic on CRLF checkouts too

### DIFF
--- a/desktop-shell/tauri-skeleton/scripts/build-frontend-export.cjs
+++ b/desktop-shell/tauri-skeleton/scripts/build-frontend-export.cjs
@@ -46,12 +46,18 @@ function prepareBuildTree() {
   const stagedLayoutPath = path.join(buildFrontendDir, 'src', 'app', 'layout.tsx');
   if (fs.existsSync(stagedLayoutPath)) {
     const layoutSource = fs.readFileSync(stagedLayoutPath, 'utf8');
+    // CRLF compatibility: on Windows checkouts without ``core.autocrlf=input``
+    // (the default) layout.tsx has CRLF line endings, but the original regexes
+    // only matched LF. The strip silently no-op'd, ``force-dynamic`` stayed,
+    // and Next's static-export refused to render ``/_not-found`` ("Page with
+    // `dynamic = \"force-dynamic\"` couldn't be exported"). Use ``\r?\n`` so
+    // the strip works regardless of line-ending normalization.
     fs.writeFileSync(
       stagedLayoutPath,
       layoutSource
-        .replace(/\n\/\/ The dashboard is a live local runtime[\s\S]*?client polling ever hydrates\.\n/g, '\n')
-        .replace(/\nexport const dynamic = ['"]force-dynamic['"];\n/g, '\n')
-        .replace(/\nexport const revalidate = 0;\n/g, '\n'),
+        .replace(/\r?\n\/\/ The dashboard is a live local runtime[\s\S]*?client polling ever hydrates\.\r?\n/g, '\n')
+        .replace(/\r?\nexport const dynamic = ['"]force-dynamic['"];\r?\n/g, '\n')
+        .replace(/\r?\nexport const revalidate = 0;\r?\n/g, '\n'),
     );
   }
 


### PR DESCRIPTION
## Summary

Discovered while building the v0.9.8 desktop bundle. `build-frontend-export.cjs` stages a desktop-only frontend export tree and strips `force-dynamic` + `revalidate` directives from `frontend/src/app/layout.tsx` so Next's `output: "export"` can prerender every route.

The strip regexes only matched LF (`\n`). On Windows checkouts without `core.autocrlf=input` (the default), the file has CRLF line endings, the strip silently no-op'd, and the desktop build failed at the static-export step:

```
Error: Page with `dynamic = "force-dynamic"` couldn't be exported.
`output: "export"` requires all pages be renderable statically because
there is no runtime server to dynamically render routes in this output
format.
Export encountered an error on /_not-found/page: /_not-found
```

This hits **every Windows contributor who hasn't normalized line endings locally**. Replacing each `\n` in the strip regexes with `\r?\n` makes the strip CRLF-tolerant; LF behavior is unchanged.

## Verification

- Ran new regex against the actual `frontend/src/app/layout.tsx` (CRLF): 302 bytes removed, both `force-dynamic` and `revalidate` gone ✅
- Ran against synthetic LF input: 296 bytes removed, same outcome ✅
- Full desktop build now succeeds end-to-end with a properly-shaped MSI (122 MB) and EXE (76 MB) — matching the v0.9.79 release shape

## Test plan

- [x] Regex verified manually on both line-ending variants
- [ ] CI green
- [ ] Future test: a unit test for `prepareBuildTree` would be a follow-up; the script is currently script-style and not easily unit-testable

Generated with Claude Code
