### PR TITLE
fix(#319,#296): v0.9.8 rebuild - bundle missing deps so backend launches

### DIFF
--- a/backend/data/release_digests.json
+++ b/backend/data/release_digests.json
@@ -38,8 +38,8 @@
     "ShadowBroker_0.9.79_x64_en-US.msi": "e0713c3cdda184cfbea750bfac0d62a35678fec00847e6476f2cac8e7e42046e"
   },
   "v0.9.8": {
-    "ShadowBroker_v0.9.8.zip": "d506f6b8462ccb12096f0cd9462233be58928094240416b65fb3127bdd1f3820",
-    "ShadowBroker_0.9.8_x64-setup.exe": "1115d1f5cf37edd03ea2c21d821c7626e1bf3319c990402aaa0293bca46fea67",
-    "ShadowBroker_0.9.8_x64_en-US.msi": "d4be4cb68c3e6409fff54c225acdcdd08e27d5d6d2b31616d78d2a4f6812991d"
+    "ShadowBroker_v0.9.8.zip": "183bb5cd62b9b9349d95df5ef7696cb6ca810ab4b991fa9dab6f898af4c7a175",
+    "ShadowBroker_0.9.8_x64-setup.exe": "94a0309862e9c81c92cdcbfea8eec9dbb97eef19ded82b26217b397defbc810c",
+    "ShadowBroker_0.9.8_x64_en-US.msi": "fe22f9d51e4360d74c18a7250c2fbb9ed4fa4c7a884b3ac0d04a21115466386b"
   }
 }


### PR DESCRIPTION
## Summary

Fixes **issues #319 and #296** — both about the installed Windows MSI/EXE crashing on launch with:

```
thread 'main' panicked ... failed to setup app: error encountered during setup hook:
ShadowBroker cannot start: the bundled local backend failed to launch.
technical detail: managed_backend_exited_early:exit code: 103
```

## Root cause

`backend/pyproject.toml` declares `defusedxml>=0.7.1` and `PySocks==1.7.1` as runtime dependencies, but the venv used to build **both v0.9.79 and the initial v0.9.8 publish** had both packages missing. When `services/fetchers/aircraft_database.py` does `import defusedxml.ElementTree` at startup, Python raises `ModuleNotFoundError`, uvicorn exits, and Tauri reports `managed_backend_exited_early`.

The Docker image was unaffected (Dockerfile installs from `pyproject.toml` properly via pip). Only the desktop-installer path shipped a broken venv.

## What this PR changes

Just `backend/data/release_digests.json` — updates the v0.9.8 hashes to point at freshly-rebuilt artifacts that include the missing dependencies in their bundled venv:

| Artifact | Old hash (broken) | New hash (working) |
|---|---|---|
| `ShadowBroker_v0.9.8.zip` | `d506f6b8…` | `183bb5cd…` |
| `ShadowBroker_0.9.8_x64_en-US.msi` | `d4be4cb6…` | `fe22f9d5…` |
| `ShadowBroker_0.9.8_x64-setup.exe` | `1115d1f5…` | `94a03098…` |

The v0.9.79 block is retained for back-compat per the file's own instructions.

## Verification

- [x] `pip install defusedxml PySocks` in the build venv resolved both `ModuleNotFoundError`s
- [x] Rebuilt MSI (122.4 MB) + EXE (76.5 MB) + zip (6.06 MB) — sizes still match the v0.9.79 reference shape
- [x] Bundled python in the new MSI imports `main.py` end-to-end with no errors (only the expected `plane_alert_db.json not found` warning, which is a runtime-state file populated on first launch)
- [x] `tests/test_update_integrity_chain.py` — 16/16 ✅

## Post-merge actions

1. Force-move the `v0.9.8` tag to this commit so the integrity-chain source matches the uploaded artifacts
2. Delete the broken assets on the GitHub release for v0.9.8
3. Upload the rebuilt MSI / EXE / zip / SHA256SUMS / release-manifest
4. Mirror to GitLab

Generated with Claude Code
