### PR TITLE
chore(release): update v0.9.81 SHA256 digests after rebuild

### DIFF
--- a/backend/data/release_digests.json
+++ b/backend/data/release_digests.json
@@ -43,8 +43,8 @@
     "ShadowBroker_0.9.8_x64_en-US.msi": "fe22f9d51e4360d74c18a7250c2fbb9ed4fa4c7a884b3ac0d04a21115466386b"
   },
   "v0.9.81": {
-    "ShadowBroker_v0.9.81.zip": "af8c87ccdece8fbb9aadc6be63cce10d3fcba74e6d87ef83289dda6d555fd270",
-    "ShadowBroker_0.9.81_x64-setup.exe": "4e866fa0423c0c2470ed32f4809167a7815dc23ee7762b69e95681c1f3a28250",
-    "ShadowBroker_0.9.81_x64_en-US.msi": "8977c9a1c54e1f0d030436be9c4e3d81d766cc0080699eb747649095f360c7ff"
+    "ShadowBroker_v0.9.81.zip": "f81f454bdc88e9a32c351df38212b8cfa624704d65764b971bb091eef62259c6",
+    "ShadowBroker_0.9.81_x64-setup.exe": "25e9a95d0d8ce959a7d08fe8e7406772ae24b596652793e81d1de5d02510a5a6",
+    "ShadowBroker_0.9.81_x64_en-US.msi": "34e655fc0c0f195ee4ac978f228a4b2b9d5565253b8771aca9ef4693409e9e70"
   }
 }


### PR DESCRIPTION
Re-cut v0.9.81 binaries from current main (with #326 private hashchain + #327 gate test). All three artifacts signed with the same minisign updater key as original v0.9.81, so existing Tauri auto-update clients accept the new bundles.

Verified against released assets at https://github.com/BigBodyCobain/Shadowbroker/releases/tag/v0.9.81 .

🤖 Generated with [Claude Code](https://claude.com/claude-code)