### PR TITLE
chore(ci): bump .gitlab-ci.yml comment to verify post-verification runner allocation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,10 @@
 #   2. Reverse-mirrors main back to GitHub (only if commits land directly
 #      on GitLab) so the two sources stay in sync.
 #
+# Pipelines on this repo were instant-failing for free-tier accounts until
+# identity verification was added — the May 2026 bump in this comment is
+# the marker commit that confirms runner allocation after verification.
+#
 # Auth notes:
 #   - The image build/push uses $CI_JOB_TOKEN, which GitLab provides
 #     automatically. No credentials need to be configured.


### PR DESCRIPTION
Trivial one-line comment bump in .gitlab-ci.yml. Sole purpose: when this merges, the fresh commit on main mirrors to GitLab and fires a new pipeline. We'll learn whether the recent identity verification actually unlocked shared runners (every pipeline since project creation has instant-failed with 0 jobs, classic unverified-account pattern).

If the resulting pipeline succeeds and builds + pushes the backend and frontend Docker images to egistry.gitlab.com/bigbodycobain/shadowbroker/{backend,frontend}, the GitLab install path reaches full parity with the GitHub one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)