### PR TITLE
fix(ci): wrap GitLab dind TLS env in docker context so buildx accepts it

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,11 @@ variables:
     - docker info
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
     - docker run --privileged --rm tonistiigi/binfmt --install all
-    - docker buildx create --use --name multiarch --driver docker-container
+    # buildx --driver docker-container can't read TLS from the env vars
+    # the GitLab dind service exports. Wrap them in a docker context and
+    # bind buildx to it. See https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-buildx
+    - docker context create tls-env
+    - docker buildx create --use --name multiarch --driver docker-container tls-env
 
 # ── Backend image ────────────────────────────────────────────────────────
 build-backend:


### PR DESCRIPTION
Post-verification GitLab pipeline pinpointed a real config bug in .gitlab-ci.yml. Both build-backend and build-frontend jobs died at the same step with the same error:

```n`$ docker buildx create --use --name multiarch --driver docker-container
ERROR: could not create a builder instance with TLS data loaded from environment.
Please use `docker context create <context-name>` to create a context for current environment`ngo and then create a builder instance with context set to <context-name>`n```

Fix: create an empty docker context (which inherits the dind TLS env vars), then pass that context as a positional arg to `buildx create`. Standard documented GitLab workaround.

Surfaced by: https://gitlab.com/bigbodycobain/Shadowbroker/-/pipelines/2550501798 .

After merge + mirror, the fresh pipeline should build + push multi-arch backend/frontend images to `registry.gitlab.com/bigbodycobain/shadowbroker/{backend,frontend}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)