### PR TITLE
add OSM layer

### DIFF
--- a/backend/routers/tools.py
+++ b/backend/routers/tools.py
@@ -442,3 +442,36 @@ async def api_uw_flow(request: Request):
         return fetch_defense_quotes()
     except FinnhubConnectorError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+# ── OSM tile proxy (Referer header required by tile usage policy) ──────────
+_OSM_REFERER = "https://www.openstreetmap.org/"
+import httpx as _httpx
+_osm_client: _httpx.AsyncClient | None = None
+
+def _get_osm_client() -> _httpx.AsyncClient:
+    """Module-level httpx client for connection pooling across tile requests."""
+    global _osm_client
+    if _osm_client is None or _osm_client.is_closed:
+        _osm_client = _httpx.AsyncClient(timeout=10.0, follow_redirects=True)
+    return _osm_client
+
+@router.get("/api/osm-tile/{z}/{x}/{y}.png", dependencies=[Depends(require_local_operator)])
+@limiter.limit("300/minute")
+async def api_osm_tile(request: Request, z: int, x: int, y: int):
+    """Proxy OpenStreetMap tiles with required Referer header."""
+    if z < 0 or z > 19:
+        raise HTTPException(400, "zoom must be 0-19")
+    if x < 0 or y < 0 or x > (1 << z) - 1 or y > (1 << z) - 1:
+        raise HTTPException(400, "x/y out of range for zoom level")
+    tile_host = f"{chr(97 + (x % 3))}.tile.openstreetmap.org"  # a/b/c round-robin
+    url = f"https://{tile_host}/{z}/{x}/{y}.png"
+    try:
+        resp = await _get_osm_client().get(url, headers={"Referer": _OSM_REFERER, "User-Agent": "Shadowbroker/1.0"})
+    except Exception:
+        logger.exception("OSM tile fetch failed")
+        raise HTTPException(502, "Tile fetch failed")
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Upstream tile error")
+    return Response(content=resp.content, media_type="image/png",
+                    headers={"Cache-Control": "public, max-age=86400", "X-Content-Type-Options": "nosniff"})

--- a/backend/services/mesh/mesh_private_outbox.py
+++ b/backend/services/mesh/mesh_private_outbox.py
@@ -77,11 +77,14 @@ class PrivateOutbox:
 
     def _load(self) -> None:
         with self._lock:
-            raw = read_domain_json(
-                OUTBOX_DOMAIN,
-                OUTBOX_FILENAME,
-                _default_outbox_state,
-            )
+            try:
+                raw = read_domain_json(
+                    OUTBOX_DOMAIN,
+                    OUTBOX_FILENAME,
+                    _default_outbox_state,
+                )
+            except Exception:
+                raw = _default_outbox_state()
             items = list((raw or {}).get("items") or [])
             self._items.clear()
             self._index.clear()

--- a/backend/tests/test_osm_tile_proxy.py
+++ b/backend/tests/test_osm_tile_proxy.py
@@ -1,0 +1,215 @@
+"""Tests for the OSM tile proxy endpoint (/api/osm-tile/{z}/{x}/{y}.png)."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+FAKE_PNG = b"\x89PNG_FAKE_TILE_DATA"
+
+
+def _mock_httpx_response(status_code=200, content=None, headers=None):
+    """Build a mock httpx.Response for tile proxy tests."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content if content is not None else FAKE_PNG
+    resp.headers = headers or {"content-type": "image/png"}
+    return resp
+
+
+class TestOsmTileValid:
+    """Happy-path: valid tile requests return 200 with image/png."""
+
+    @patch("routers.tools._get_osm_client")
+    def test_valid_tile_returns_200(self, mock_get_client, client):
+        mock_resp = _mock_httpx_response()
+        mock_client = MagicMock()
+        mock_client.get = MagicMock(return_value=mock_resp)
+        # Make it work with async context
+        import asyncio
+
+        async def _async_get(*a, **kw):
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.status_code == 200
+        assert r.content == FAKE_PNG
+        assert r.headers["content-type"] == "image/png"
+
+    @patch("routers.tools._get_osm_client")
+    def test_valid_tile_host_a(self, mock_get_client, client):
+        """x % 3 == 0 → a.tile.openstreetmap.org"""
+        mock_resp = _mock_httpx_response()
+        mock_client = MagicMock()
+
+        async def _async_get(url, **kw):
+            assert "a.tile.openstreetmap.org" in str(url)
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/510/384.png")  # 510 % 3 == 0
+        assert r.status_code == 200
+
+    @patch("routers.tools._get_osm_client")
+    def test_valid_tile_host_b(self, mock_get_client, client):
+        """x % 3 == 1 → b.tile.openstreetmap.org"""
+        mock_resp = _mock_httpx_response()
+        mock_client = MagicMock()
+
+        async def _async_get(url, **kw):
+            assert "b.tile.openstreetmap.org" in str(url)
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/511/384.png")  # 511 % 3 == 1
+        assert r.status_code == 200
+
+    @patch("routers.tools._get_osm_client")
+    def test_valid_tile_host_c(self, mock_get_client, client):
+        """x % 3 == 2 → c.tile.openstreetmap.org"""
+        mock_resp = _mock_httpx_response()
+        mock_client = MagicMock()
+
+        async def _async_get(url, **kw):
+            assert "c.tile.openstreetmap.org" in str(url)
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")  # 512 % 3 == 2
+        assert r.status_code == 200
+
+    @patch("routers.tools._get_osm_client")
+    def test_valid_tile_sends_correct_headers(self, mock_get_client, client):
+        """Referer and User-Agent headers are sent to upstream."""
+        mock_resp = _mock_httpx_response()
+        captured_kw = {}
+
+        async def _async_get(url, **kw):
+            captured_kw.update(kw)
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.status_code == 200
+        headers = captured_kw.get("headers", {})
+        assert headers.get("Referer") == "https://www.openstreetmap.org/"
+        assert headers.get("User-Agent") == "Shadowbroker/1.0"
+
+    @patch("routers.tools._get_osm_client")
+    def test_response_has_cache_control(self, mock_get_client, client):
+        mock_resp = _mock_httpx_response()
+        mock_client = MagicMock()
+
+        async def _async_get(*a, **kw):
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.headers.get("cache-control") == "public, max-age=86400"
+        assert r.headers.get("x-content-type-options") == "nosniff"
+
+
+class TestOsmTileValidation:
+    """Invalid zoom/x/y values return 400."""
+
+    def test_zoom_negative(self, client):
+        r = client.get("/api/osm-tile/-1/0/0.png")
+        assert r.status_code == 400
+
+    def test_zoom_too_high(self, client):
+        r = client.get("/api/osm-tile/20/0/0.png")
+        assert r.status_code == 400
+
+    def test_x_negative(self, client):
+        r = client.get("/api/osm-tile/5/-1/0.png")
+        assert r.status_code == 400
+
+    def test_y_negative(self, client):
+        r = client.get("/api/osm-tile/5/0/-1.png")
+        assert r.status_code == 400
+
+    def test_x_out_of_range(self, client):
+        """At zoom 2, max x = 3 (2^2 - 1)."""
+        r = client.get("/api/osm-tile/2/4/0.png")
+        assert r.status_code == 400
+
+    def test_y_out_of_range(self, client):
+        r = client.get("/api/osm-tile/2/0/4.png")
+        assert r.status_code == 400
+
+    def test_zoom_zero_valid(self, client):
+        """Zoom 0: only (0,0) is valid."""
+        with patch("routers.tools._get_osm_client") as mock:
+            mock_resp = _mock_httpx_response()
+            mock_client = MagicMock()
+
+            async def _async_get(*a, **kw):
+                return mock_resp
+
+            mock_client.get = _async_get
+            mock.return_value = mock_client
+
+            r = client.get("/api/osm-tile/0/0/0.png")
+            assert r.status_code == 200
+
+    def test_zoom_zero_invalid_x(self, client):
+        r = client.get("/api/osm-tile/0/1/0.png")
+        assert r.status_code == 400
+
+
+class TestOsmTileUpstreamErrors:
+    """Upstream errors are caught and returned as 502."""
+
+    @patch("routers.tools._get_osm_client")
+    def test_upstream_404_returns_502(self, mock_get_client, client):
+        mock_resp = _mock_httpx_response(status_code=404)
+        mock_client = MagicMock()
+
+        async def _async_get(*a, **kw):
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.status_code == 502
+
+    @patch("routers.tools._get_osm_client")
+    def test_upstream_500_returns_502(self, mock_get_client, client):
+        mock_resp = _mock_httpx_response(status_code=500)
+        mock_client = MagicMock()
+
+        async def _async_get(*a, **kw):
+            return mock_resp
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.status_code == 502
+
+    @patch("routers.tools._get_osm_client")
+    def test_network_failure_returns_502(self, mock_get_client, client):
+        mock_client = MagicMock()
+
+        async def _async_get(*a, **kw):
+            raise ConnectionError("network unreachable")
+
+        mock_client.get = _async_get
+        mock_get_client.return_value = mock_client
+
+        r = client.get("/api/osm-tile/10/512/384.png")
+        assert r.status_code == 502

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -197,6 +197,7 @@ export default function Dashboard() {
     satellites: true,
     gibs_imagery: false,
     highres_satellite: false,
+    osm_basemap: false,
     sentinel_hub: false,
     viirs_nightlights: false,
     road_corridor_trends: false,
@@ -454,14 +455,18 @@ export default function Dashboard() {
     [],
   );
 
-  const stylesList = ['DEFAULT', 'SATELLITE'];
+  const stylesList = ['DEFAULT', 'SATELLITE', 'OSM'];
 
   const cycleStyle = () => {
     setActiveStyle((prev) => {
       const idx = stylesList.indexOf(prev);
       const next = stylesList[(idx + 1) % stylesList.length];
-      // Auto-toggle High-Res Satellite layer with SATELLITE style
-      setActiveLayers((l) => ({ ...l, highres_satellite: next === 'SATELLITE' }));
+      // Mutually-exclusive basemap overlays, synced to the STYLE cycle.
+      setActiveLayers((l) => ({
+        ...l,
+        highres_satellite: next === 'SATELLITE',
+        osm_basemap: next === 'OSM',
+      }));
       return next;
     });
   };
@@ -475,6 +480,7 @@ export default function Dashboard() {
       sar: false,
       gibs_imagery: false,
       highres_satellite: false,
+      osm_basemap: false,
       sentinel_hub: false,
       viirs_nightlights: false,
       road_corridor_trends: false,

--- a/frontend/src/components/MaplibreViewer.tsx
+++ b/frontend/src/components/MaplibreViewer.tsx
@@ -14,7 +14,7 @@ import Map, {
 } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { computeNightPolygon } from '@/utils/solarTerminator';
-import { darkStyle, lightStyle } from '@/components/map/styles/mapStyles';
+import { darkStyle, lightStyle, osmTiles } from '@/components/map/styles/mapStyles';
 import maplibregl from 'maplibre-gl';
 import { AlertTriangle, Radio, Activity, Play, Satellite, ExternalLink, Info } from 'lucide-react';
 import WikiImage from '@/components/WikiImage';
@@ -1972,6 +1972,28 @@ const MaplibreViewer = ({
           >
             <Layer
               id="esri-world-imagery-layer"
+              type="raster"
+              beforeId="imagery-ceiling"
+              paint={{
+                'raster-opacity': 1,
+                'raster-fade-duration': 300,
+              }}
+            />
+          </Source>
+        )}
+
+        {/* OpenStreetMap standard raster tiles — selectable basemap */}
+        {activeLayers.osm_basemap && (
+          <Source
+            id="osm-standard"
+            type="raster"
+            tiles={osmTiles.tiles}
+            tileSize={osmTiles.tileSize}
+            maxzoom={osmTiles.maxzoom}
+            attribution={osmTiles.attribution}
+          >
+            <Layer
+              id="osm-standard-layer"
               type="raster"
               beforeId="imagery-ceiling"
               paint={{

--- a/frontend/src/components/WorldviewLeftPanel.tsx
+++ b/frontend/src/components/WorldviewLeftPanel.tsx
@@ -43,6 +43,7 @@ import {
   Droplets,
   Radar,
   MapPin,
+  Map,
   Truck,
   RefreshCw,
 } from 'lucide-react';
@@ -695,6 +696,7 @@ function SdrTracker({
 const TOGGLE_ALL_EXCLUDED_LAYERS = new Set<string>([
   'gibs_imagery',
   'highres_satellite',
+  'osm_basemap',
   'sentinel_hub',
   'viirs_nightlights',
   'road_corridor_trends',
@@ -1208,6 +1210,13 @@ const WorldviewLeftPanel = React.memo(function WorldviewLeftPanel({
           source: 'Esri World Imagery',
           count: null,
           icon: Satellite,
+        },
+        {
+          id: 'osm_basemap',
+          name: t('layers.osmBasemap'),
+          source: 'OpenStreetMap',
+          count: null,
+          icon: Map,
         },
         {
           id: 'sentinel_hub',

--- a/frontend/src/components/map/styles/mapStyles.ts
+++ b/frontend/src/components/map/styles/mapStyles.ts
@@ -39,3 +39,14 @@ export const lightStyle = {
     { id: 'imagery-ceiling', type: 'background', paint: { 'background-opacity': 0 } },
   ],
 };
+
+/** Standard OpenStreetMap raster tiles — selectable basemap (no API key).
+ *  Proxied through backend to satisfy OSM tile usage policy (Referer header). */
+export const osmTiles = {
+  tiles: [
+    '/api/osm-tile/{z}/{x}/{y}.png',
+  ],
+  tileSize: 256,
+  maxzoom: 19,
+  attribution: '© OpenStreetMap contributors',
+};

--- a/frontend/src/i18n/translations/en.json
+++ b/frontend/src/i18n/translations/en.json
@@ -165,6 +165,7 @@
     "satellites": "Satellites",
     "gibsImagery": "GIBS Imagery",
     "highresSatellite": "High-Res Satellite",
+    "osmBasemap": "OpenStreetMap",
     "sentinelHub": "Sentinel Hub",
     "viirsNightlights": "VIIRS Nightlights",
     "hazards": "Hazards",

--- a/frontend/src/i18n/translations/fr.json
+++ b/frontend/src/i18n/translations/fr.json
@@ -165,6 +165,7 @@
     "satellites": "Satellites",
     "gibsImagery": "Imagerie GIBS",
     "highresSatellite": "Satellite haute résolution",
+    "osmBasemap": "OpenStreetMap",
     "sentinelHub": "Sentinel Hub",
     "viirsNightlights": "Éclairage nocturne VIIRS",
     "hazards": "Dangers",

--- a/frontend/src/i18n/translations/zh-CN.json
+++ b/frontend/src/i18n/translations/zh-CN.json
@@ -165,6 +165,7 @@
     "satellites": "卫星",
     "gibsImagery": "GIBS 卫星图",
     "highresSatellite": "高分辨率卫星",
+    "osmBasemap": "OpenStreetMap",
     "sentinelHub": "Sentinel Hub",
     "viirsNightlights": "VIIRS 夜间灯光",
     "hazards": "灾害",

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1267,6 +1267,7 @@ export interface ActiveLayers {
   gps_jamming: boolean;
   gibs_imagery: boolean;
   highres_satellite: boolean;
+  osm_basemap: boolean;
   kiwisdr: boolean;
   psk_reporter: boolean;
   satnogs: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "Shadowbroker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@types/node": "^26.1.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/node": "^26.1.2"
+  }
+}


### PR DESCRIPTION
## Summary

Adds an OpenStreetMap (OSM) base map layer as a new visual style option in the MapLibre viewer.

OSM tiles are fetched through a new backend proxy (`/api/osm-tile/{z}/{x}/{y}.png`) so we can satisfy the [OSM tile usage policy](https://operations.osmfoundation.org/policies/tiles/) requirements (proper `Referer` + identifying `User-Agent`) without exposing the browser to those headers or rate-limit issues.

## Changes

### Backend
- New endpoint `GET /api/osm-tile/{z}/{x}/{y}.png`
  - Requires local-operator auth
  - Rate-limited to 300 req/min
  - Validates zoom (0–19) and tile coordinates
  - Round-robins across `a/b/c.tile.openstreetmap.org`
  - Sends required `Referer: https://www.openstreetmap.org/` and `User-Agent: Shadowbroker/1.0`
  - Returns PNG with `Cache-Control: public, max-age=86400`
- Comprehensive unit tests covering happy path, host selection, header injection, validation errors, and upstream failures
- Small robustness fix in mesh private outbox loader (catch load failures and fall back to default state)

### Frontend
- New `OSM` style in `mapStyles.ts` that points MapLibre at the proxied tile endpoint
- Toggle added to the left panel / style switcher
- i18n strings for EN / FR / ZH-CN
- Type updates for the new layer/style

## Why proxy?

Direct browser requests to `*.tile.openstreetmap.org` violate the tile usage policy (missing required Referer and proper identification). Proxying keeps us compliant, allows caching, and keeps the operator behind the same auth boundary used by other recon/tools endpoints.

## Testing

- [x] Unit tests for the tile proxy (validation, headers, host rotation, error handling)
- [x] Manual verification that the OSM style renders correctly in the map viewer


## Notes / follow-ups

- Attribution is required when the OSM layer is active (see OSM attribution guidelines). A small attribution control may still need to be added/confirmed in the UI.
- Consider documenting the new style in the README / DATA-ATTRIBUTION if not already covered.