### PR TITLE
fix(store): make agent layer injection copy-on-write

### DIFF
--- a/backend/services/ai_intel_store.py
+++ b/backend/services/ai_intel_store.py
@@ -137,15 +137,16 @@ def inject_layer_data(
         tagged.append(entry)
 
     with _data_lock:
-        existing = latest_data.get(layer)
-        if not isinstance(existing, list):
-            existing = []
+        current = latest_data.get(layer)
+        existing = list(current) if isinstance(current, list) else []
 
         if mode == "replace":
             existing = [e for e in existing if not e.get("_injected")]
 
-        existing.extend(tagged)
-        latest_data[layer] = existing
+        # Readers can hold references to published layer lists after releasing
+        # _data_lock. Build a fresh list and swap it atomically rather than
+        # mutating the published object in place with list.extend().
+        latest_data[layer] = [*existing, *tagged]
 
     bump_data_version()
 

--- a/backend/tests/test_ai_intel_store_copy_on_write.py
+++ b/backend/tests/test_ai_intel_store_copy_on_write.py
@@ -1,0 +1,59 @@
+"""Regression coverage for copy-on-write OpenClaw layer injection."""
+
+from services import ai_intel_store
+from services.fetchers import _store
+
+
+def _publish_test_layer(monkeypatch, items):
+    published = list(items)
+    monkeypatch.setitem(_store.latest_data, "air_quality", published)
+    monkeypatch.setattr(_store, "bump_data_version", lambda: None)
+    return published
+
+
+def test_append_does_not_mutate_previously_published_list(monkeypatch):
+    before = _publish_test_layer(monkeypatch, [{"id": "existing"}])
+
+    result = ai_intel_store.inject_layer_data(
+        "air_quality",
+        [{"id": "injected"}],
+        mode="append",
+    )
+
+    after = _store.latest_data["air_quality"]
+    assert result == {
+        "ok": True,
+        "layer": "air_quality",
+        "injected": 1,
+        "mode": "append",
+    }
+    assert after is not before
+    assert before == [{"id": "existing"}]
+    assert [item["id"] for item in after] == ["existing", "injected"]
+    assert after[-1]["_injected"] is True
+    assert after[-1]["_source"] == "user:openclaw"
+
+
+def test_replace_does_not_mutate_previously_published_list(monkeypatch):
+    before = _publish_test_layer(
+        monkeypatch,
+        [
+            {"id": "native"},
+            {"id": "old-injected", "_injected": True},
+        ],
+    )
+
+    result = ai_intel_store.inject_layer_data(
+        "air_quality",
+        [{"id": "new-injected"}],
+        mode="replace",
+    )
+
+    after = _store.latest_data["air_quality"]
+    assert result["ok"] is True
+    assert after is not before
+    assert before == [
+        {"id": "native"},
+        {"id": "old-injected", "_injected": True},
+    ]
+    assert [item["id"] for item in after] == ["native", "new-injected"]


### PR DESCRIPTION
## Summary

- Stop `inject_layer_data()` from mutating a list that has already been published through `latest_data`.
- Build a fresh list under `_data_lock` and atomically replace the layer reference instead of calling `existing.extend(...)` on the published object.
- Add regression coverage for both `append` and `replace` modes, asserting that a previously published list remains unchanged.

This is the sibling in-place mutation called out as a follow-up in PR #388. Readers can retain references to `latest_data` layer values and serialize them after the store lock is released, so mutating the published list in place can race those readers. The copy-on-write swap follows the same replace-don't-mutate contract used elsewhere in the store.

## Test plan

- [x] Added `backend/tests/test_ai_intel_store_copy_on_write.py` with property-level coverage for append and replace behavior.
- [ ] Upstream CI.

## Production hardening

Checklist reviewed.

- **Config and exposure:** N/A. No flags, routes, auth, or exposure changes.
- **Live-data API:** Response shape and serializers are unchanged. Only the publication strategy for injected layer lists changes.
- **Fetcher pools and timeouts:** N/A. No network or executor changes.
- **Secrets and observability:** N/A.
- **Memory:** bounded. Injection is already capped at 200 items; this allocates one replacement list per injection and releases the old store reference.
- **Tests:** assert the concurrency-relevant property directly: callers holding the previously published list must not observe it being mutated.

Follow-up to PR #388.