### PR TITLE
perf/throttle-fast-startup-cache: Throttle fast startup cache writes to ten minutes

### DIFF
--- a/backend/services/data_fetcher.py
+++ b/backend/services/data_fetcher.py
@@ -114,7 +114,15 @@ _SLOW_FETCH_S = float(os.environ.get("FETCH_SLOW_THRESHOLD_S", "5"))
 # is treated as a failure so it cannot block an entire fetch tier indefinitely.
 _TASK_HARD_TIMEOUT_S = float(os.environ.get("FETCH_TASK_TIMEOUT_S", "120"))
 _FAST_STARTUP_CACHE_MAX_AGE_S = float(os.environ.get("FAST_STARTUP_CACHE_MAX_AGE_S", "21600"))
+# The fast tier runs every 60s but this cache is only read at cold boot, where a
+# stale-by-hours copy is still accepted (see _FAST_STARTUP_CACHE_MAX_AGE_S).  Writing
+# the multi-MB snapshot on every tick is wasted CPU + disk, so throttle it.
+_FAST_STARTUP_CACHE_SAVE_INTERVAL_S = float(
+    os.environ.get("FAST_STARTUP_CACHE_SAVE_INTERVAL_S", "600")
+)
 _FAST_STARTUP_CACHE_PATH = Path(__file__).resolve().parents[1] / "data" / "fast_startup_cache.json"
+# Monotonic timestamp of the last *successful* fast startup cache write (0 = never).
+_last_fast_startup_cache_save = 0.0
 _FAST_STARTUP_CACHE_KEYS = (
     "commercial_flights",
     "military_flights",
@@ -223,8 +231,20 @@ def _load_fast_startup_cache_if_available() -> bool:
         return False
 
 
-def _save_fast_startup_cache() -> None:
-    """Persist recent moving layers for the next cold start."""
+def _save_fast_startup_cache(force: bool = False) -> None:
+    """Persist recent moving layers for the next cold start.
+
+    Throttled to ``_FAST_STARTUP_CACHE_SAVE_INTERVAL_S`` because the snapshot is only
+    consumed at cold boot.  Pass ``force=True`` (shutdown flush) to bypass the throttle.
+    """
+    global _last_fast_startup_cache_save
+    now = time.monotonic()
+    if (
+        not force
+        and _last_fast_startup_cache_save
+        and (now - _last_fast_startup_cache_save) < _FAST_STARTUP_CACHE_SAVE_INTERVAL_S
+    ):
+        return
     try:
         with _data_lock:
             layers = {
@@ -245,9 +265,14 @@ def _save_fast_startup_cache() -> None:
         safe_payload = _cache_json_safe(payload)
         _FAST_STARTUP_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = _FAST_STARTUP_CACHE_PATH.with_suffix(".tmp")
+        # One big write beats json.dump()'s thousands of small writes into the buffered
+        # file object (~4.5x faster on a 20MB snapshot).
+        encoded = json.dumps(safe_payload, separators=(",", ":"))
         with tmp_path.open("w", encoding="utf-8") as fh:
-            json.dump(safe_payload, fh, separators=(",", ":"))
+            fh.write(encoded)
         tmp_path.replace(_FAST_STARTUP_CACHE_PATH)
+        # Only advance on success so a failed write retries on the next tick.
+        _last_fast_startup_cache_save = time.monotonic()
     except Exception as e:
         logger.debug("Fast startup cache save skipped: %s", e)
 
@@ -1287,6 +1312,11 @@ def start_scheduler():
 
 
 def stop_scheduler():
+    # Flush the throttled fast startup cache so a clean restart still boots warm.
+    try:
+        _save_fast_startup_cache(force=True)
+    except Exception as e:
+        logger.debug("Fast startup cache shutdown flush skipped: %s", e)
     if _scheduler:
         _scheduler.shutdown(wait=False)
     _SLOW_EXECUTOR.shutdown(wait=False, cancel_futures=True)

--- a/backend/tests/test_fast_startup_cache_throttle.py
+++ b/backend/tests/test_fast_startup_cache_throttle.py
@@ -1,0 +1,136 @@
+"""Regression tests for the throttled fast startup cache writer.
+
+The fast tier runs every 60s but the snapshot it persists is only read at cold
+boot, where staleness up to ``FAST_STARTUP_CACHE_MAX_AGE_S`` (6h) is accepted.
+``_save_fast_startup_cache`` therefore throttles itself; these tests pin that
+behaviour (and the shutdown-flush bypass) so it cannot silently regress.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Captured at import time: the autouse conftest fixture patches
+# ``services.data_fetcher.stop_scheduler`` with a MagicMock for every test, so grab a
+# reference to the real function before that happens.
+from services.data_fetcher import stop_scheduler as _real_stop_scheduler
+
+
+@pytest.fixture()
+def cache_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Point the cache at a tmp dir, reset the throttle, and fake the clock."""
+    from services import data_fetcher
+
+    cache_path = tmp_path / "fast_startup_cache.json"
+    monkeypatch.setattr(data_fetcher, "_FAST_STARTUP_CACHE_PATH", cache_path)
+    monkeypatch.setattr(data_fetcher, "_FAST_STARTUP_CACHE_SAVE_INTERVAL_S", 600.0)
+    monkeypatch.setattr(data_fetcher, "_last_fast_startup_cache_save", 0.0)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(data_fetcher.time, "monotonic", lambda: clock["now"])
+
+    # A tiny payload so the test never writes a real multi-MB snapshot.
+    monkeypatch.setattr(data_fetcher, "_FAST_STARTUP_CACHE_KEYS", ("ships",))
+    monkeypatch.setitem(data_fetcher.latest_data, "ships", [{"id": "vessel-1"}])
+
+    return data_fetcher, cache_path, clock
+
+
+def test_second_save_within_interval_is_skipped(cache_env):
+    data_fetcher, cache_path, clock = cache_env
+
+    data_fetcher._save_fast_startup_cache()
+    assert cache_path.exists()
+    first_mtime = cache_path.stat().st_mtime_ns
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["layers"]["ships"] == [{"id": "vessel-1"}]
+
+    # Next fast-tier tick, 60s later: still inside the 600s window.
+    clock["now"] += 60.0
+    data_fetcher.latest_data["ships"] = [{"id": "vessel-2"}]
+    data_fetcher._save_fast_startup_cache()
+
+    assert cache_path.stat().st_mtime_ns == first_mtime
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["layers"]["ships"] == [{"id": "vessel-1"}]
+
+
+def test_save_resumes_once_interval_elapses(cache_env):
+    data_fetcher, cache_path, clock = cache_env
+
+    data_fetcher._save_fast_startup_cache()
+    clock["now"] += 601.0
+    data_fetcher.latest_data["ships"] = [{"id": "vessel-2"}]
+    data_fetcher._save_fast_startup_cache()
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["layers"]["ships"] == [{"id": "vessel-2"}]
+
+
+def test_force_bypasses_throttle(cache_env):
+    data_fetcher, cache_path, clock = cache_env
+
+    data_fetcher._save_fast_startup_cache()
+    clock["now"] += 1.0
+    data_fetcher.latest_data["ships"] = [{"id": "vessel-2"}]
+    data_fetcher._save_fast_startup_cache(force=True)
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert payload["layers"]["ships"] == [{"id": "vessel-2"}]
+
+
+def test_failed_write_does_not_advance_throttle(cache_env, monkeypatch):
+    data_fetcher, cache_path, clock = cache_env
+
+    real_dumps = data_fetcher.json.dumps
+    fail = {"on": True}
+
+    def maybe_boom(*args, **kwargs):
+        if fail["on"]:
+            raise OSError("disk full")
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr(data_fetcher.json, "dumps", maybe_boom)
+    data_fetcher._save_fast_startup_cache()
+    assert not cache_path.exists()
+    assert data_fetcher._last_fast_startup_cache_save == 0.0
+
+    # The very next tick must retry rather than being suppressed for 10 minutes.
+    fail["on"] = False
+    clock["now"] += 60.0
+    data_fetcher._save_fast_startup_cache()
+    assert cache_path.exists()
+
+
+def test_stop_scheduler_flushes_cache(monkeypatch):
+    from services import data_fetcher
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        data_fetcher,
+        "_save_fast_startup_cache",
+        lambda force=False: calls.append(force),
+    )
+    monkeypatch.setattr(data_fetcher, "_scheduler", None)
+    monkeypatch.setattr(data_fetcher._SLOW_EXECUTOR, "shutdown", lambda **kw: None)
+
+    _real_stop_scheduler()
+    assert calls == [True]
+
+
+def test_stop_scheduler_survives_flush_failure(monkeypatch):
+    from services import data_fetcher
+
+    def boom(force=False):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(data_fetcher, "_save_fast_startup_cache", boom)
+    monkeypatch.setattr(data_fetcher, "_scheduler", None)
+    shutdown_calls: list[dict] = []
+    monkeypatch.setattr(
+        data_fetcher._SLOW_EXECUTOR, "shutdown", lambda **kw: shutdown_calls.append(kw)
+    )
+
+    _real_stop_scheduler()
+    assert shutdown_calls, "executor shutdown must still run after a flush failure"


### PR DESCRIPTION
## Summary

`update_fast_data()` runs on the APScheduler `fast_tier` job every **60 seconds**, and it calls `_save_fast_startup_cache()` unconditionally at the end. That function serializes the entire fast tier to `backend/data/fast_startup_cache.json`, currently **20.8 MB**.

That file has exactly one consumer: `_load_fast_startup_cache_if_available()` at cold boot, which already tolerates staleness up to `_FAST_STARTUP_CACHE_MAX_AGE_S` = **21600 s (6 hours)**.

So a 20.8 MB file is rewritten 60x/hour to serve a reader that accepts 6-hour-old data. A cold boot startup from the cache doesn't need to be minute-accurate. Extended to 10 minutes. A stopped scheduler already writes to cache automatically.

## Measured cost

Measured on a developer machine (Python 3.10) against a real 20.8 MB snapshot, per 60 s cycle:

| Step | Time |
|---|---|
| `_cache_json_safe(payload)` (recursive rebuild of the whole tree) | 1401 ms |
| `json.dump(safe_payload, fh, ...)` streaming into the file object | 4939 ms |
| **Total** | **~6.34 s** |

That is **~10.6% of one core, continuously**, plus 20.8 MB x 60/hr = **1.25 GB/hour** of disk writes.

Separately measured: `json.dumps(...)` to a string followed by a single `fh.write(s)` takes **1101 ms** versus 4939 ms for `json.dump` streaming into the buffered file object: a **4.5x** speedup, because `json.dump` emits thousands of small writes.

## Changes

1. **Throttle the save to ~10 minutes.** New module-level constant `_FAST_STARTUP_CACHE_SAVE_INTERVAL_S` (default 600 s, env-overridable via `FAST_STARTUP_CACHE_SAVE_INTERVAL_S`, declared in the same style as the neighbouring constants). `_save_fast_startup_cache()` returns early before taking `_data_lock` and before `_cache_json_safe` when the last successful save was inside the interval, so none of the expensive work runs. The timestamp is only advanced after a **successful** write, so a failed write retries on the next tick instead of being suppressed for 10 minutes.
2. **Flush on shutdown.** `stop_scheduler()` calls `_save_fast_startup_cache(force=True)` to bypass the throttle, wrapped so a failure during shutdown cannot raise.
3. **`json.dumps` + one `write` instead of `json.dump`.** The existing atomic tmp-file-then-`replace()` pattern is unchanged.

Lock scope is unchanged: payload assembly stays under `_data_lock`, serialization and the write stay outside it, exactly as before.

## Expected result

- CPU: ~6.34 s per 60 s -> ~2.5 s per 600 s. **~10.6% of a core -> ~0.42%, roughly 96% less CPU** for this path. (The ~2.5 s figure combines the 10x lower frequency with the faster write; the `json.dumps` change also cuts the latency of each individual save.)
- Disk: **1.25 GB/hr -> ~125 MB/hr, ~90% less write I/O.**
- The `json` C encoder holds the GIL, so this also removes most of the event-loop jitter this path contributes.

Cold-boot warmth is preserved: the loader already accepts a cache up to 6 hours old, so a snapshot that is at most ~10 minutes stale is well inside tolerance, and a clean shutdown now flushes a fresh copy before exit.

The numbers above were measured on a developer machine against a real 20.8 MB snapshot; absolute values will differ on other hardware, but the ratios are what the change is aiming at.

## Tests

- [x] `cd backend && ../.venv/bin/python -m pytest tests/test_fast_startup_cache_throttle.py -q`: **6 passed in 0.77s**.
- [x] Targeted selection on this branch vs base `b6516a2` in a clean worktree, `-k "startup_cache or data_fetcher or fast"`: branch `4 failed, 26 passed`, base `4 failed, 20 passed`. Identical 4 failures on both (`test_mesh_gate_mls`, `test_5e_meshtastic_transport`, `test_api_smoke`, `test_sigint_cctv_accuracy`), all `FileNotFoundError` from tests that hardcode a repo-root-relative path while `pytest.ini` lives in `backend/`. Pre-existing, unrelated to this change. The 20 -> 26 delta is exactly the 6 new tests.
- [x] `ruff check` clean on both changed files.
