### PR TITLE
perf/store-ref-read-only-endpoints: Read single store layers by reference on the SIGINT endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4082,8 +4082,9 @@ async def oracle_region_intel(
 ):
     """Get oracle intelligence summary for a geographic region."""
     from services.oracle_service import get_region_oracle_intel
+    from services.fetchers._store import get_latest_data_subset_refs
 
-    news_items = get_latest_data().get("news", [])
+    news_items = get_latest_data_subset_refs("news").get("news") or []
     return get_region_oracle_intel(lat, lng, news_items)
 
 
@@ -4135,8 +4136,9 @@ async def nearest_sdr(
 ):
     """Find the nearest KiwiSDR receivers to a given coordinate."""
     from services.sigint_bridge import find_nearest_kiwisdr
+    from services.fetchers._store import get_latest_data_subset_refs
 
-    kiwisdr_data = get_latest_data().get("kiwisdr", [])
+    kiwisdr_data = get_latest_data_subset_refs("kiwisdr").get("kiwisdr") or []
     return find_nearest_kiwisdr(lat, lng, kiwisdr_data)
 
 
@@ -4721,7 +4723,9 @@ async def mesh_messages(
 @limiter.limit("30/minute")
 async def mesh_channels(request: Request):
     """Get Meshtastic channel population stats â€” nodes per region/channel."""
-    stats = get_latest_data().get("mesh_channel_stats", {})
+    from services.fetchers._store import get_latest_data_subset_refs
+
+    stats = get_latest_data_subset_refs("mesh_channel_stats").get("mesh_channel_stats") or {}
     return stats
 
 
@@ -6459,8 +6463,10 @@ async def oracle_predict(request: Request):
         pass
 
     # Get current market probability from live data
-    data = get_latest_data()
-    markets = data.get("prediction_markets", [])
+    from services.fetchers._store import get_latest_data_subset_refs
+
+    data = get_latest_data_subset_refs("prediction_markets")
+    markets = data.get("prediction_markets") or []
     matched = None
     for m in markets:
         if m.get("title", "").lower() == market_title.lower():
@@ -6537,8 +6543,10 @@ async def oracle_markets(request: Request):
     from collections import defaultdict
     from services.mesh.mesh_oracle import oracle_ledger
 
-    data = get_latest_data()
-    markets = data.get("prediction_markets", [])
+    from services.fetchers._store import get_latest_data_subset_refs
+
+    data = get_latest_data_subset_refs("prediction_markets")
+    markets = data.get("prediction_markets") or []
 
     # Get consensus for all active markets (bulk)
     all_consensus = oracle_ledger.get_all_market_consensus()
@@ -6601,8 +6609,10 @@ async def oracle_search(request: Request, q: str = "", limit: int = 20, offset: 
     kalshi_results = search_kalshi_direct(q, limit=provider_limit, offset=0)
 
     # Also search cached merged data so cross-provider consensus entries win.
-    data = get_latest_data()
-    markets = data.get("prediction_markets", [])
+    from services.fetchers._store import get_latest_data_subset_refs
+
+    data = get_latest_data_subset_refs("prediction_markets")
+    markets = data.get("prediction_markets") or []
     q_lower = q.lower()
     cached_matches = [m for m in markets if q_lower in m.get("title", "").lower()]
 
@@ -6657,8 +6667,10 @@ async def oracle_markets_more(
     category = (category or "NEWS").upper()
     offset = max(0, int(offset or 0))
     limit = max(1, min(int(limit or 10), 100))
-    data = get_latest_data()
-    markets = data.get("prediction_markets", [])
+    from services.fetchers._store import get_latest_data_subset_refs
+
+    data = get_latest_data_subset_refs("prediction_markets")
+    markets = data.get("prediction_markets") or []
     cat_markets = sorted(
         [m for m in markets if category == "ALL" or m.get("category") == category],
         key=lambda x: x.get("volume", 0) or 0,
@@ -8158,7 +8170,9 @@ async def trust_vouches(request: Request, node_id: str = "", limit: int = 20):
 @app.get("/api/debug-latest", dependencies=[Depends(require_admin)])
 @limiter.limit("30/minute")
 async def debug_latest_data(request: Request):
-    return list(get_latest_data().keys())
+    from services.fetchers._store import get_latest_data_refs_snapshot
+
+    return list(get_latest_data_refs_snapshot().keys())
 
 
 # â”€â”€ CCTV media proxy (bypass CORS for cross-origin video/image streams) â”€â”€â”€
@@ -8682,26 +8696,42 @@ async def cctv_media_proxy(request: Request, url: str = Query(...)):
 @limiter.limit("30/minute")
 async def health_check(request: Request):
     import time
-    from services.fetchers._store import get_source_timestamps_snapshot
+    from services.fetchers._store import (
+        get_latest_data_subset_refs,
+        get_source_timestamps_snapshot,
+    )
 
-    d = get_latest_data()
+    d = get_latest_data_subset_refs(
+        "last_updated",
+        "commercial_flights",
+        "military_flights",
+        "ships",
+        "satellites",
+        "earthquakes",
+        "cctv",
+        "news",
+        "uavs",
+        "firms_fires",
+        "liveuamap",
+        "gdelt",
+    )
     last = d.get("last_updated")
     return {
         "status": "ok",
         "version": APP_VERSION,
         "last_updated": last,
         "sources": {
-            "flights": len(d.get("commercial_flights", [])),
-            "military": len(d.get("military_flights", [])),
-            "ships": len(d.get("ships", [])),
-            "satellites": len(d.get("satellites", [])),
-            "earthquakes": len(d.get("earthquakes", [])),
-            "cctv": len(d.get("cctv", [])),
-            "news": len(d.get("news", [])),
-            "uavs": len(d.get("uavs", [])),
-            "firms_fires": len(d.get("firms_fires", [])),
-            "liveuamap": len(d.get("liveuamap", [])),
-            "gdelt": len(d.get("gdelt", [])),
+            "flights": len(d.get("commercial_flights") or []),
+            "military": len(d.get("military_flights") or []),
+            "ships": len(d.get("ships") or []),
+            "satellites": len(d.get("satellites") or []),
+            "earthquakes": len(d.get("earthquakes") or []),
+            "cctv": len(d.get("cctv") or []),
+            "news": len(d.get("news") or []),
+            "uavs": len(d.get("uavs") or []),
+            "firms_fires": len(d.get("firms_fires") or []),
+            "liveuamap": len(d.get("liveuamap") or []),
+            "gdelt": len(d.get("gdelt") or []),
         },
         "freshness": get_source_timestamps_snapshot(),
         "uptime_seconds": round(time.time() - _start_time),

--- a/backend/routers/sigint.py
+++ b/backend/routers/sigint.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from limiter import limiter
 from auth import require_admin, require_local_operator
-from services.data_fetcher import get_latest_data
+from services.fetchers._store import get_latest_data_subset_refs
 
 router = APIRouter()
 
@@ -17,7 +17,7 @@ async def oracle_region_intel(
 ):
     """Get oracle intelligence summary for a geographic region."""
     from services.oracle_service import get_region_oracle_intel
-    news_items = get_latest_data().get("news", [])
+    news_items = get_latest_data_subset_refs("news").get("news") or []
     return get_region_oracle_intel(lat, lng, news_items)
 
 
@@ -63,5 +63,5 @@ async def nearest_sdr(
 ):
     """Find the nearest KiwiSDR receivers to a given coordinate."""
     from services.sigint_bridge import find_nearest_kiwisdr
-    kiwisdr_data = get_latest_data().get("kiwisdr", [])
+    kiwisdr_data = get_latest_data_subset_refs("kiwisdr").get("kiwisdr") or []
     return find_nearest_kiwisdr(lat, lng, kiwisdr_data)

--- a/backend/tests/test_perf_safe_optimizations.py
+++ b/backend/tests/test_perf_safe_optimizations.py
@@ -76,3 +76,25 @@ def test_layer_enable_refresh_covers_cold_toggle_layers():
     source = inspect.getsource(layer_enable_refresh.refresh_newly_enabled_layers)
     for key in ("cctv", "firms", "power_plants", "psk_reporter", "datacenters"):
         assert key in layer_enable_refresh._INSTANT_LAYER_KEYS | layer_enable_refresh._SLOW_LAYER_KEYS
+
+
+def test_sigint_router_uses_subset_refs_not_full_deepcopy():
+    """/api/oracle/region-intel and /api/sigint/nearest-sdr each need one layer.
+
+    Both handlers are async, so a full-store deepcopy would block the event
+    loop. Their consumers (get_region_oracle_intel, find_nearest_kiwisdr) only
+    read the list they are handed, so direct refs are safe.
+    """
+    from routers import sigint as sigint_router
+
+    module_source = inspect.getsource(sigint_router)
+    assert "get_latest_data_subset_refs" in module_source
+    assert "get_latest_data()" not in module_source
+    assert "deepcopy" not in module_source
+
+    for handler, key in (
+        (sigint_router.oracle_region_intel, "news"),
+        (sigint_router.nearest_sdr, "kiwisdr"),
+    ):
+        source = inspect.getsource(handler)
+        assert f'get_latest_data_subset_refs("{key}")' in source


### PR DESCRIPTION
## Summary

`routers/sigint.py` serves `/api/oracle/region-intel` and `/api/sigint/nearest-sdr`. Both called `get_latest_data()`, which is `get_latest_data_deepcopy_snapshot()` in `services/fetchers/_store.py`, and that deep-copies every top-level layer in the store.

`/api/oracle/region-intel` needs `news`. `/api/sigint/nearest-sdr` needs `kiwisdr`. One layer each. Both were paying for a copy of all forty.

Both handlers are `async def`, so the copy runs on the event loop thread rather than in a threadpool. While it runs, every other in-flight request is stalled, not just the one that triggered it. These are click-driven endpoints rather than polled ones, so this is a latency spike rather than steady-state load, but it is a spike that hits the whole server.

`_store.py` already has the zero-copy accessors for this. `get_latest_data_subset_refs()` and `get_latest_data_refs_snapshot()` hand back direct references, which is safe because the store contract is replace-don't-mutate: writers swap top-level values under `_data_lock` instead of mutating them, so a reader that does not modify what it receives can hold a reference after releasing the lock. `routers/data.py`, `routers/health.py`, `routers/sar.py` and `services/telemetry.py` already use them.

## Measured cost

Measured on a developer machine (Python 3.10) against a real store snapshot, 20.8 MB across 17 layers:

| Operation | Time |
|---|---|
| `get_latest_data()`, full-store deepcopy | 2890 ms |
| `get_latest_data_refs_snapshot()` | 3 us |
| `get_latest_data_subset_refs(...)` plus `len()` over 11 keys | 6 us |

Plus roughly 20 MB of transient allocation per call, immediately discarded.

That snapshot was captured with AIS cold, so `ships` held 11 rows and `cctv` was absent. A warm store is larger. 2890 ms is a floor, not a typical value.

## Changes

1. **The two live handlers now read one layer by reference.** `get_latest_data_subset_refs("news")` and `get_latest_data_subset_refs("kiwisdr")` replace the full-store copy in `routers/sigint.py`.

2. **Checked both consumers before converting.** This is the part that makes refs safe or unsafe, so it was verified rather than assumed. `get_region_oracle_intel` (`services/oracle_service.py:334`) iterates the list read-only, collects references into its own new `nearby` list, and uses `max()` and comprehensions. `find_nearest_kiwisdr` (`services/sigint_bridge.py:1426`) builds new dicts into its own `results` list and calls `.sort()` on that list, never on the input. Neither mutates, appends to, or sorts in place what it is handed.

3. **Converted the nine remaining `get_latest_data()` calls in `main.py`.** These give no runtime gain whatsoever. Every one of them is a duplicate route that a router module also registers, and `include_router` runs at `main.py:3842`, before the `@app.get` decorators execute, so the router handler is the one that serves the request and these bodies never run. This is the situation already documented and CI-guarded by `tests/test_no_new_duplicate_routes.py`. Converting them is drift hygiene: if one of the shadowed copies is ever resurrected, it should not bring the full-deepcopy pattern back with it. Listing it here as a change, not as a speedup.

4. **Handled the missing-key difference.** `get_latest_data_subset_refs` always inserts the key, so an absent layer comes back as `None` rather than as a missing key. The old call sites relied on `.get(key, [])` defaults, which would have become `len(None)` and raised a `TypeError` on the first request before a layer populated. Every converted site now uses `.get(key) or []`, including the twelve `len()` calls in the shadowed health handler.

Call sites use a function-local `from services.fetchers._store import ...`, matching the existing pattern in `routers/data.py` and `services/openclaw_channel.py`. That keeps mesh-only mode working, since `_store` has no heavy dependencies.

`main.py` still imports `get_latest_data` at line 210 and defines a mesh-only stub at 223. Both are now unused. Left alone rather than widen the diff, and ruff does not flag them.

## Expected result

- Per call on the two live endpoints: **2890 ms -> roughly 6 us**, and about 20 MB of transient allocation down to none.
- The event loop is no longer blocked for seconds at a time by a region-intel or nearest-SDR request, so the tail latency of every concurrent request improves, not only these two.
- No change to steady-state load. Nothing here runs on a timer.

## Tests

Extended `tests/test_perf_safe_optimizations.py` with `test_sigint_router_uses_subset_refs_not_full_deepcopy`, which pins the sigint router to the reference accessor and asserts each handler names the single key it reads. This matches the guards already in that file for the health and live-data routers.

- [x] Targeted selection on this branch: `9 failed, 60 passed, 2611 deselected in 18.32s`. Same selection on base `b6516a2` in a clean worktree: `9 failed, 59 passed`. Same patch applied on top of base in a third worktree: `9 failed, 59 passed`. The failure set is identical across all three. The 59 -> 60 delta is the one new test.
- [x] `ruff check` clean on all three changed files.

Failures common to branch and base: `test_s12a_root_distribution_http` (x2), `test_2b_data_access::test_exactly_seven_keys_in_subscription`, `test_ais_spki_pinning` (x2), `test_api_smoke::test_health_returns_200`, `test_no_new_duplicate_routes`, `test_sigint_cctv_accuracy` (x2).

One of those is worth flagging separately, since it will look like this branch caused it. `test_no_new_duplicate_routes` fails on base `main` already:

```
+ POST /api/wormhole/dm/contact/{peer_id}/sever  (NEW duplicate; registered in: ['main', 'routers.wormhole'])
```

That is baseline drift from an earlier change: a duplicate route was added without regenerating `tests/data/duplicate_routes_baseline.json`. It will fail CI on any PR against `main` until the baseline is regenerated with `python -m scripts.regen_duplicate_routes_baseline`. Unrelated to this branch, and deliberately not fixed here.
