### PR TITLE
perf/static-worker-zoom-dep: Drop mapZoom from the static map layer sync deps

### DIFF
--- a/frontend/src/components/MaplibreViewer.tsx
+++ b/frontend/src/components/MaplibreViewer.tsx
@@ -1360,7 +1360,6 @@ const MaplibreViewer = ({
       staticCrowdthreat,
       staticMalwareThreats,
       staticTelegramOsintPosts,
-      mapZoom,
     ],
     {
       bounds: mapBounds,


### PR DESCRIPTION
## Summary

The `useStaticMapLayersWorker(...)` call in `frontend/src/components/MaplibreViewer.tsx` passed a `dataDeps` array whose last entry was `mapZoom`. Zoom carries no data, so that entry could never change what the worker produced. It only changed how often the worker ran.

The cost is larger than a stray dependency usually is, because it cascades. In `frontend/src/components/map/hooks/useStaticMapLayersWorker.ts`:

- the effect keyed on `dataDeps` posts the entire `dataPayload`, all 23 static layers, to the web worker via `callWorker({ action: 'sync_static_layers', ... })`, which is a full structured clone;
- on success it calls `setSyncVersion(...)`;
- `syncVersion` is the **first** entry in the *build* effect's dependency list.

So one zoom-end triggered a structured clone of every static layer, then a full rebuild, then the roughly 23 `setData` uploads that follow. A single wheel scroll emits several zoom-end events.

## Why removing it is safe

`mapZoom` is not part of `dataPayload`, which holds only `staticCctv`, `staticKiwisdr`, `staticPskReporter`, `staticSatnogsStations`, `staticScanners`, `staticFirmsFires`, `staticInternetOutages`, `staticDatacenters`, `staticPowerPlants`, `staticViirsChangeNodes`, `staticMilitaryBases`, `staticGdelt`, `staticLiveuamap`, `staticAirQuality`, `staticVolcanoes`, `staticFishingActivity`, `data?.ships`, `staticTrains`, `staticUapSightings`, `staticWastewater`, `staticCrowdthreat`, `staticMalwareThreats` and `staticTelegramOsintPosts`.

Checks made before removing it:

- **No `static*` memo feeding that payload reads `mapZoom`**, in its body or in its own dependency array. All 23 were checked.
- **`staticMapLayers.worker.ts` contains zero occurrences of the string `zoom`**, so neither `sync_static_layers` nor `build_static_layers` can produce zoom-dependent output at all.
- **`mapZoom` was never in `buildDeps`** either, which is `mapBounds` plus the 22 `activeLayers.*` flags. Nothing is being relocated from one dependency list to the other. This is a pure deletion.
- **`mapBounds` still changes on zoom and remains in `buildDeps`**, so genuine viewport-driven rebuilds are preserved. Zooming still rebuilds when the viewport actually changes; it just no longer re-syncs the unchanged source data first.

Every other use of `mapZoom` in the file is unrelated and untouched: the alert-spreading memo, the `zoom={mapZoom}` props passed to child components, a `mapZoom >= 5` render guard, and a fly-to target.

## Changes

```diff
@@ -1360,7 +1360,6 @@ const MaplibreViewer = ({
       staticCrowdthreat,
       staticMalwareThreats,
       staticTelegramOsintPosts,
-      mapZoom,
     ],
     {
       bounds: mapBounds,
```

One line, one file.

## Expected result

A zoom that does not change the underlying data no longer pays for a structured clone of all 23 static layers, a full rebuild, and the `setData` uploads that follow. Those layers include `datacenters` at about 1.5 MB on disk, plus `military_bases`, `gdelt`, `cctv`, `firms_fires` and 18 others, so the clone is not small.

No measured figure is quoted. Getting one needs a running browser with instrumented worker messages, which was not done here. The mechanism is the point: the work removed could not have produced different output.

## Tests

No new test was added. This is a dependency-array entry whose removal changes no behaviour, only how often existing behaviour is triggered, and there is no natural assertion for it that would not just restate the diff.

The only existing test touching this hook is `frontend/src/__tests__/map/maplibreDecomposition.test.ts:253`, which asserts the string `'useStaticMapLayersWorker'` appears in the viewer. It makes no claim about dependency arrays, so it needed no update.

- [x] `cd frontend && npx vitest run --pool=threads`: **86 files / 794 tests passed**, no failures or skips.
- [x] `npx tsc --noEmit`: **170 errors, all pre-existing**, zero of them in `MaplibreViewer.tsx`. Confirmed rather than assumed, by running the same check on base `b6516a2` in a separate worktree with `node_modules` symlinked: also exactly 170.
- [x] `npx eslint src/components/MaplibreViewer.tsx`: 0 errors, 11 warnings, all pre-existing and unrelated (an unused `flightHasKnownRoute`, several `no-explicit-any`, and one `exhaustive-deps` about `dynamicRoute` at line 1635). No new warning was introduced, since no lint rule inspects this custom hook's dependency arrays.