### PR TITLE
perf/viewport-bounds-gating: Hold the culling box steady while the viewport stays inside its pad

### DIFF
--- a/frontend/src/__tests__/hooks/useViewportBoundsGating.test.ts
+++ b/frontend/src/__tests__/hooks/useViewportBoundsGating.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Culling-box gating in useViewportBounds.
+ *
+ * `mapBounds` is a build dependency of both layer workers in
+ * MaplibreViewer, so every new array reference rebuilds ~36 layers and
+ * re-uploads them to the GPU. The hook therefore only republishes the padded
+ * box when the retained one stops being usable.
+ *
+ * The invariant that makes the gate safe: whatever `mapBounds` holds must
+ * always fully contain the visible viewport, because `inView()` culls against
+ * it. An oversized box is harmless (features render that did not need to);
+ * an undersized box makes on-screen features disappear.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useViewportBounds } from '@/components/map/hooks/useViewportBounds';
+import { setLiveDataBounds } from '@/lib/liveDataViewport';
+
+type Visible = { west: number; south: number; east: number; north: number };
+
+function makeMapRef(initial: Visible) {
+  const visible = { ...initial };
+  const map = {
+    getBounds: () => ({
+      getWest: () => visible.west,
+      getSouth: () => visible.south,
+      getEast: () => visible.east,
+      getNorth: () => visible.north,
+    }),
+  };
+  return {
+    ref: { current: { getMap: () => map } } as never,
+    setVisible(next: Visible) {
+      Object.assign(visible, next);
+    },
+    get visible(): Visible {
+      return { ...visible };
+    },
+  };
+}
+
+/** A viewport centered on (lat, lng) spanning `span` degrees each way. */
+function box(lat: number, lng: number, span: number): Visible {
+  return {
+    west: lng - span / 2,
+    south: lat - span / 2,
+    east: lng + span / 2,
+    north: lat + span / 2,
+  };
+}
+
+function contains(bounds: [number, number, number, number], v: Visible): boolean {
+  return (
+    v.west >= bounds[0] && v.south >= bounds[1] && v.east <= bounds[2] && v.north <= bounds[3]
+  );
+}
+
+describe('useViewportBounds — mapBounds gating', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    setLiveDataBounds(null);
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // City-scale viewport: ~0.02 degrees across. This is the scale at which an
+  // absolute-degree gate (e.g. VIEWPORT_CHANGE_EPSILON = 1.5) would never fire
+  // and culling would silently break.
+  const CITY_SPAN = 0.02;
+
+  it('commits a padded box on the first update', () => {
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+
+    const bounds = result.current.mapBounds;
+    expect(contains(bounds, map.visible)).toBe(true);
+    // 20% pad on each side => the box spans 1.4x the visible box.
+    expect(bounds[2] - bounds[0]).toBeCloseTo(CITY_SPAN * 1.4, 10);
+    expect(bounds[3] - bounds[1]).toBeCloseTo(CITY_SPAN * 1.4, 10);
+  });
+
+  it('keeps the same reference for a small pan that stays inside the pad', () => {
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+    const first = result.current.mapBounds;
+
+    // Nudge by 10% of the span — well inside the 20% pad.
+    map.setVisible(box(51.5 + CITY_SPAN * 0.1, -0.12 + CITY_SPAN * 0.1, CITY_SPAN));
+    act(() => result.current.updateBounds());
+
+    expect(result.current.mapBounds).toBe(first);
+    expect(contains(result.current.mapBounds, map.visible)).toBe(true);
+  });
+
+  it('is idempotent when called twice for the same camera (onMoveEnd + onIdle)', () => {
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+    const first = result.current.mapBounds;
+    act(() => result.current.updateBounds());
+
+    expect(result.current.mapBounds).toBe(first);
+  });
+
+  it('updates when a pan escapes the pad', () => {
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+    const first = result.current.mapBounds;
+
+    // Pan by 50% of the span — past the 20% pad.
+    map.setVisible(box(51.5, -0.12 + CITY_SPAN * 0.5, CITY_SPAN));
+    act(() => result.current.updateBounds());
+
+    expect(result.current.mapBounds).not.toBe(first);
+    expect(contains(result.current.mapBounds, map.visible)).toBe(true);
+  });
+
+  it('updates when zooming out', () => {
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+    const first = result.current.mapBounds;
+
+    map.setVisible(box(51.5, -0.12, CITY_SPAN * 2));
+    act(() => result.current.updateBounds());
+
+    expect(result.current.mapBounds).not.toBe(first);
+    expect(contains(result.current.mapBounds, map.visible)).toBe(true);
+  });
+
+  it('tightens the box after zooming in', () => {
+    const map = makeMapRef(box(51.5, -0.12, 40));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+    const wide = result.current.mapBounds;
+
+    // A single zoom level in (span halves) already trips the shrink gate:
+    // 0.5 / 1.4 is below the 0.5 ratio threshold.
+    map.setVisible(box(51.5, -0.12, 20));
+    act(() => result.current.updateBounds());
+    const tighter = result.current.mapBounds;
+
+    expect(tighter).not.toBe(wide);
+    expect(tighter[2] - tighter[0]).toBeLessThan(wide[2] - wide[0]);
+
+    // Keep zooming: the box must track down to city scale, not stay world-sized.
+    for (let span = 10; span >= CITY_SPAN; span /= 2) {
+      map.setVisible(box(51.5, -0.12, span));
+      act(() => result.current.updateBounds());
+    }
+    const bounds = result.current.mapBounds;
+    expect(bounds[2] - bounds[0]).toBeLessThan(CITY_SPAN * 4);
+    expect(contains(bounds, map.visible)).toBe(true);
+  });
+
+  it('never lets the retained box exceed ~2x the visible span', () => {
+    const map = makeMapRef(box(0, 0, 8));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+
+    act(() => result.current.updateBounds());
+
+    for (let span = 8; span >= 0.05; span *= 0.9) {
+      map.setVisible(box(0, 0, span));
+      act(() => result.current.updateBounds());
+      const bounds = result.current.mapBounds;
+      expect(contains(bounds, map.visible)).toBe(true);
+      expect(bounds[2] - bounds[0]).toBeLessThanOrEqual(span * 2 + 1e-9);
+      expect(bounds[3] - bounds[1]).toBeLessThanOrEqual(span * 2 + 1e-9);
+    }
+  });
+
+  it('holds the containment invariant across a long mixed sequence of moves', () => {
+    const map = makeMapRef(box(0, 0, 30));
+    const { result } = renderHook(() => useViewportBounds(map.ref, undefined, false));
+    act(() => result.current.updateBounds());
+
+    // Deterministic pseudo-random walk of pans and zooms.
+    let seed = 12345;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed / 2147483648;
+    };
+
+    let lat = 0;
+    let lng = 0;
+    let span = 30;
+    let updates = 0;
+    let previous = result.current.mapBounds;
+
+    for (let i = 0; i < 400; i += 1) {
+      // Pan by up to +/-35% of the span, and jitter the zoom by up to ~1.25x
+      // either way, so the sequence contains both gated and ungated moves.
+      lat = Math.max(-60, Math.min(60, lat + (rand() - 0.5) * span * 0.7));
+      lng = Math.max(-160, Math.min(160, lng + (rand() - 0.5) * span * 0.7));
+      span = Math.max(0.01, Math.min(60, span * (0.8 + rand() * 0.45)));
+
+      map.setVisible(box(lat, lng, span));
+      act(() => result.current.updateBounds());
+
+      const bounds = result.current.mapBounds;
+      // The invariant, checked after every single move.
+      expect(contains(bounds, map.visible)).toBe(true);
+      if (bounds !== previous) {
+        updates += 1;
+        previous = bounds;
+      }
+    }
+
+    // Sanity: the gate is a gate, not a freeze — it both fires and holds.
+    expect(updates).toBeGreaterThan(0);
+    expect(updates).toBeLessThan(400);
+  });
+
+  it('keeps the non-gated side effects running on every call', async () => {
+    const { liveDataBoundsKey } = await import('@/lib/liveDataViewport');
+    const map = makeMapRef(box(51.5, -0.12, CITY_SPAN));
+    const viewBoundsRef: { current: unknown } = { current: null };
+    const { result } = renderHook(
+      () => useViewportBounds(map.ref, viewBoundsRef as never, false),
+    );
+
+    setLiveDataBounds(null);
+    act(() => result.current.updateBounds());
+    const firstBounds = result.current.mapBounds;
+    const firstRef = viewBoundsRef.current;
+    expect(firstRef).not.toBeNull();
+    expect(liveDataBoundsKey()).not.toBeNull();
+
+    // A pan small enough to be gated out of mapBounds must still refresh
+    // viewBoundsRef and the live-data bounds.
+    setLiveDataBounds(null);
+    map.setVisible(box(51.5 + CITY_SPAN * 0.05, -0.12, CITY_SPAN));
+    act(() => result.current.updateBounds());
+
+    expect(result.current.mapBounds).toBe(firstBounds);
+    expect(viewBoundsRef.current).not.toBe(firstRef);
+    expect(liveDataBoundsKey()).not.toBeNull();
+  });
+});

--- a/frontend/src/components/map/hooks/useViewportBounds.ts
+++ b/frontend/src/components/map/hooks/useViewportBounds.ts
@@ -15,6 +15,30 @@ const VIEWPORT_POST_MIN_INTERVAL_MS = 12000;
 const VIEWPORT_CHANGE_EPSILON = 1.5;
 export const VIEWPORT_COMMITTED_EVENT = 'shadowbroker:viewport-committed';
 
+// Fraction of the visible span added on every side when padding the culling
+// box. 0.2 => the padded box spans 1.4x the visible box on each axis.
+const MAP_BOUNDS_PAD = 0.2;
+
+// How far the visible span may shrink, relative to the span of the padded box
+// we last committed, before we re-tighten the culling box.
+//
+// A freshly committed box spans 1.4x the visible box. One zoom level in halves
+// the visible span, so the ratio after a single zoom-in step is
+// 0.5 / 1.4 ≈ 0.36 — comfortably under this threshold, meaning zooming in
+// always re-tightens within one level rather than leaving a world-sized box
+// pinned forever. Holding the line at 0.5 also caps how oversized a retained
+// box can be: we only keep it while visibleSpan >= 0.5 * committedSpan, i.e.
+// the box is never more than ~2x the visible span per axis. Over-inclusion is
+// harmless (extra features render); under-inclusion would cull visible
+// features, so the gate is deliberately one-sided.
+const MAP_BOUNDS_SHRINK_RATIO = 0.5;
+
+// Deliberately NOT VIEWPORT_CHANGE_EPSILON: that is an absolute 1.5-degree
+// threshold sized for the backend viewport POST. A city-level viewport spans
+// ~0.02 degrees, so an absolute gate of that size would freeze the culling box
+// while panning and features would vanish. Everything here is relative to the
+// current viewport span.
+
 function boundsChanged(a: ViewBounds | null, b: ViewBounds): boolean {
   if (!a) return true;
   return (
@@ -23,6 +47,63 @@ function boundsChanged(a: ViewBounds | null, b: ViewBounds): boolean {
     Math.abs(a.north - b.north) > VIEWPORT_CHANGE_EPSILON ||
     Math.abs(a.east - b.east) > VIEWPORT_CHANGE_EPSILON
   );
+}
+
+type PaddedBounds = [number, number, number, number];
+
+/**
+ * Decide whether the culling box has to be replaced.
+ *
+ * `committed` is the padded box currently held in `mapBounds`; the four
+ * `visible*` values are the map's current visible bounds. Returns true when
+ * the committed box no longer fully contains the visible viewport (a pan
+ * escaped the pad, or a zoom-out grew past it) or when the viewport has
+ * shrunk far enough that the committed box is wastefully oversized.
+ */
+function shouldRecommitBounds(
+  committed: PaddedBounds | null,
+  visibleWest: number,
+  visibleSouth: number,
+  visibleEast: number,
+  visibleNorth: number,
+): boolean {
+  if (!committed) return true;
+  if (
+    !Number.isFinite(visibleWest) ||
+    !Number.isFinite(visibleSouth) ||
+    !Number.isFinite(visibleEast) ||
+    !Number.isFinite(visibleNorth)
+  ) {
+    // Degenerate camera reading — recommit rather than risk keeping a box that
+    // no longer covers what is on screen.
+    return true;
+  }
+
+  // 1. Containment. Any escape at all invalidates the box: keeping a box that
+  //    does not cover the viewport would cull features that are on screen.
+  if (
+    visibleWest < committed[0] ||
+    visibleSouth < committed[1] ||
+    visibleEast > committed[2] ||
+    visibleNorth > committed[3]
+  ) {
+    return true;
+  }
+
+  // 2. Oversize. The box still contains the viewport, but the viewport has
+  //    shrunk enough that we are culling far less than we could.
+  const committedLngSpan = committed[2] - committed[0];
+  const committedLatSpan = committed[3] - committed[1];
+  const visibleLngSpan = visibleEast - visibleWest;
+  const visibleLatSpan = visibleNorth - visibleSouth;
+  if (committedLngSpan > 0 && visibleLngSpan < committedLngSpan * MAP_BOUNDS_SHRINK_RATIO) {
+    return true;
+  }
+  if (committedLatSpan > 0 && visibleLatSpan < committedLatSpan * MAP_BOUNDS_SHRINK_RATIO) {
+    return true;
+  }
+
+  return false;
 }
 
 export function useViewportBounds(
@@ -39,20 +120,45 @@ export function useViewportBounds(
   const lastPostedBoundsRef = useRef<ViewBounds | null>(null);
   const lastPostedAtRef = useRef(0);
   const lastCommittedBoundsRef = useRef<ViewBounds | null>(null);
+  // The padded box currently published as `mapBounds`. Kept separate from
+  // lastCommittedBoundsRef / lastPostedBoundsRef, which throttle the
+  // viewport-committed event and the backend POST on their own schedules.
+  const committedMapBoundsRef = useRef<PaddedBounds | null>(null);
 
   const updateBounds = useCallback(() => {
     const map = mapRef.current?.getMap();
     if (!map) return;
     const b = map.getBounds();
-    const latRange = b.getNorth() - b.getSouth();
-    const lngRange = b.getEast() - b.getWest();
-    const buf = 0.2; // 20% buffer
-    setMapBounds([
-      b.getWest() - lngRange * buf,
-      b.getSouth() - latRange * buf,
-      b.getEast() + lngRange * buf,
-      b.getNorth() + latRange * buf,
-    ]);
+    const visibleWest = b.getWest();
+    const visibleSouth = b.getSouth();
+    const visibleEast = b.getEast();
+    const visibleNorth = b.getNorth();
+    const latRange = visibleNorth - visibleSouth;
+    const lngRange = visibleEast - visibleWest;
+
+    // `mapBounds` is a dependency of the layer-building workers, so a new
+    // array reference rebuilds every static and dynamic layer. Only publish a
+    // new box when the retained one stops being usable — see
+    // shouldRecommitBounds. The invariant is that whatever sits in
+    // `mapBounds` always fully contains the visible viewport.
+    if (
+      shouldRecommitBounds(
+        committedMapBoundsRef.current,
+        visibleWest,
+        visibleSouth,
+        visibleEast,
+        visibleNorth,
+      )
+    ) {
+      const next: PaddedBounds = [
+        visibleWest - lngRange * MAP_BOUNDS_PAD,
+        visibleSouth - latRange * MAP_BOUNDS_PAD,
+        visibleEast + lngRange * MAP_BOUNDS_PAD,
+        visibleNorth + latRange * MAP_BOUNDS_PAD,
+      ];
+      committedMapBoundsRef.current = next;
+      setMapBounds(next);
+    }
 
     const normalized = normalizeViewBounds({
       south: b.getSouth(),


### PR DESCRIPTION
## Summary

`updateBounds()` in `frontend/src/components/map/hooks/useViewportBounds.ts` built a fresh array on every call:

```js
setMapBounds([
  b.getWest()  - lngRange * buf,
  b.getSouth() - latRange * buf,
  b.getEast()  + lngRange * buf,
  b.getNorth() + latRange * buf,
]);   // buf = 0.2
```

A new array is a new reference, so `mapBounds` changed identity on every call whether or not the camera had meaningfully moved. `mapBounds` is a build dependency of both worker hooks in `MaplibreViewer.tsx`, the static one and the dynamic one, so each call rebuilt 23 static and roughly 13 dynamic layers and pushed about 55 `setData` uploads to the GPU.

`MaplibreViewer` calls `updateBounds()` from both `onMoveEnd` and `onIdle`, so most interactions paid that twice.

The box already carries 20% padding on every side. After a small pan the previous box usually still covers the screen completely, so nothing needed rebuilding at all.

## The invariant this rests on

`mapBounds` drives `inView()` culling, so:

> whatever sits in `mapBounds` must always fully contain the visible viewport.

The two failure modes are not symmetric. An oversized box is harmless: some off-screen features render that did not need to. An undersized box culls features that are on screen, so they silently disappear during a pan with no error and no failing test. The gate is therefore deliberately one-sided, with zero tolerance on containment.

This is also why the existing `VIEWPORT_CHANGE_EPSILON` is not reused here. It is an absolute 1.5 degree threshold sized for the backend viewport POST. A city-level viewport spans about 0.02 degrees, so an absolute gate that size would freeze the culling box while panning and make on-screen features vanish. Everything in the new gate is relative to the current viewport span. A comment at the constant's definition records this so nobody wires the two together later.

## Changes

1. **New pure helper `shouldRecommitBounds(committed, visibleWest, visibleSouth, visibleEast, visibleNorth)`.** Returns true when:
   - `committed` is null, i.e. the first call;
   - any visible edge is non-finite, a degenerate camera reading, in which case it recommits rather than risk keeping a box that no longer covers the screen;
   - **containment fails**, `visibleWest < committed[0] || visibleSouth < committed[1] || visibleEast > committed[2] || visibleNorth > committed[3]`, with no tolerance at all;
   - **oversize**, the visible span has dropped below half the committed span on either axis.

2. **Two named constants replace the inline literal.** `MAP_BOUNDS_PAD = 0.2`, extracted from the old inline `buf`, and `MAP_BOUNDS_SHRINK_RATIO = 0.5`, both commented at their definitions.

3. **Containment state lives in a new `committedMapBoundsRef`**, holding the exact array last handed to `setMapBounds`. `lastCommittedBoundsRef` and `lastPostedBoundsRef` are untouched, since they throttle the viewport-committed event and the backend POST on their own separate schedules.

4. **Only `setMapBounds` is gated.** `viewBoundsRef.current`, the `VIEWPORT_COMMITTED_EVENT` dispatch, `setLiveDataBounds()` and the debounced `/api/viewport` POST all still run unconditionally on every call, outside the `if`. A test asserts this directly: a pan that is gated out of `mapBounds` still refreshes `viewBoundsRef` and the live-data bounds.

5. **`onMoveEnd` and `onIdle` both keep calling `updateBounds`.** `onIdle` also fires for programmatic camera moves and after tile loads, `onMoveEnd` only at the end of a user gesture, so neither strictly dominates and dropping either could miss an update. With the gate in place the duplicate call is a `getBounds()` and four comparisons with no state write, so there is nothing left to win by removing it. `MaplibreViewer.tsx` is unmodified.

### Why 0.5 for the shrink ratio

A freshly committed box spans 1.4x the visible box. One zoom level in halves the visible span, so the ratio after a single zoom-in step is `0.5 / 1.4`, about 0.36, comfortably under the threshold. Zooming in therefore always re-tightens within one level rather than leaving a world-sized box pinned. The same number caps how oversized a retained box can get: it is kept only while `visibleSpan >= 0.5 * committedSpan`, so never more than about 2x the visible span per axis.

Zooming out grows the visible box and trips the containment condition on its own, so it needs no separate rule.

## Expected result

- A pan that stays inside the 20% pad now rebuilds nothing, against 23 static and about 13 dynamic layers and roughly 55 `setData` uploads before.
- The second half of every `onMoveEnd` / `onIdle` pair is now a no-op.
- Pans that escape the pad, and every zoom-out, still rebuild, as they have to.

No number is quoted for the aggregate saving. Measuring it properly needs a running browser with instrumented layer builds, which was not done here, and the real figure depends entirely on how a given operator pans. The mechanism is what the change is aiming at.

## Tests

New file `frontend/src/__tests__/hooks/useViewportBoundsGating.test.ts`, 9 tests, mocking `map.getBounds()` rather than instantiating a real map:

- commits a padded box on the first update
- keeps the same reference for a small pan that stays inside the pad
- is idempotent when called twice for the same camera, the `onMoveEnd` plus `onIdle` case
- updates when a pan escapes the pad
- updates when zooming out
- tightens the box after zooming in
- never lets the retained box exceed about 2x the visible span
- holds the containment invariant across a long mixed sequence of moves
- keeps the non-gated side effects running on every call

The tests were mutation-checked to confirm they fail for the right reasons rather than passing vacuously. Hard-wiring the gate to never fire failed 5 of 9. Loosening containment by 0.5 degrees on the west edge only, which is exactly the silent-culling bug this change could introduce, failed 1 of 9, caught by the invariant walk. Both mutants were reverted and the file was verified against a backup afterwards.

- [x] `cd frontend && npx vitest run --pool=threads`: **87 files / 803 tests passed**, against a base of 86 files / 794 tests. The delta is exactly the 9 new tests.
- [x] `npx tsc --noEmit`: **170 errors, identical to base**, none in `useViewportBounds.ts`. All 170 are pre-existing fixture typing issues in `*.test.ts(x)`.
- [x] `npx eslint` on both changed files: clean, 0 errors and 0 warnings.
- [x] `npx prettier --check` on both changed files: clean.