### PR TITLE
fix(store): preserve non-mapping native layer entries

### DIFF
--- a/backend/services/ai_intel_store.py
+++ b/backend/services/ai_intel_store.py
@@ -141,7 +141,11 @@ def inject_layer_data(
         existing = list(current) if isinstance(current, list) else []
 
         if mode == "replace":
-            existing = [e for e in existing if not e.get("_injected")]
+            existing = [
+                entry
+                for entry in existing
+                if not (isinstance(entry, dict) and entry.get("_injected"))
+            ]
 
         # Readers can hold references to published layer lists after releasing
         # _data_lock. Build a fresh list and swap it atomically rather than
@@ -170,7 +174,11 @@ def clear_injected_data(layer: str = "") -> dict[str, Any]:
             if not isinstance(existing, list):
                 continue
             before = len(existing)
-            latest_data[lyr] = [e for e in existing if not e.get("_injected")]
+            latest_data[lyr] = [
+                entry
+                for entry in existing
+                if not (isinstance(entry, dict) and entry.get("_injected"))
+            ]
             removed += before - len(latest_data[lyr])
 
     if removed:

--- a/backend/tests/test_ai_intel_store_mixed_items.py
+++ b/backend/tests/test_ai_intel_store_mixed_items.py
@@ -1,0 +1,46 @@
+"""Regression coverage for mixed native entries during injected-data cleanup."""
+
+from services import ai_intel_store
+from services.fetchers import _store
+
+
+def _publish_mixed_layer(monkeypatch):
+    published = [
+        "native-sentinel",
+        {"id": "native"},
+        {"id": "old-injected", "_injected": True},
+    ]
+    monkeypatch.setitem(_store.latest_data, "air_quality", published)
+    monkeypatch.setattr(_store, "bump_data_version", lambda: None)
+    return published
+
+
+def test_replace_preserves_non_mapping_native_entries(monkeypatch):
+    before = _publish_mixed_layer(monkeypatch)
+
+    result = ai_intel_store.inject_layer_data(
+        "air_quality",
+        [{"id": "new-injected"}],
+        mode="replace",
+    )
+
+    after = _store.latest_data["air_quality"]
+    assert result["ok"] is True
+    assert after is not before
+    assert after[0] == "native-sentinel"
+    assert [item.get("id") for item in after if isinstance(item, dict)] == [
+        "native",
+        "new-injected",
+    ]
+
+
+def test_clear_preserves_non_mapping_native_entries(monkeypatch):
+    _publish_mixed_layer(monkeypatch)
+
+    result = ai_intel_store.clear_injected_data("air_quality")
+
+    assert result == {"ok": True, "removed": 1}
+    assert _store.latest_data["air_quality"] == [
+        "native-sentinel",
+        {"id": "native"},
+    ]


### PR DESCRIPTION
## Summary

- make injected-data replacement tolerate native layer entries that are not mappings
- preserve those native entries while removing only entries explicitly tagged as injected
- apply the same safe cleanup rule to `clear_injected_data`
- add regression coverage for mixed native/injected layer contents

## Why

The cleanup paths currently call `.get()` on every existing layer item. A non-mapping native entry therefore raises during `replace`/clear instead of being preserved.

## Test plan

- focused regression tests in `backend/tests/test_ai_intel_store_mixed_items.py`
- upstream CI

Normal dict-only layer behavior is unchanged.