### PR TITLE
fix(infonet): ignore invalid timestamps in majority time

### DIFF
--- a/backend/services/infonet/tests/test_time_validity_invalid_timestamps.py
+++ b/backend/services/infonet/tests/test_time_validity_invalid_timestamps.py
@@ -1,13 +1,15 @@
 """Regression coverage for malformed chain timestamps."""
 
+from typing import Any
+
 from services.infonet.time_validity import chain_majority_time, is_event_too_future
 
 
-def _event(node_id: str, timestamp):
+def _event(node_id: str, timestamp: Any) -> dict[str, Any]:
     return {"node_id": node_id, "timestamp": timestamp}
 
 
-def test_chain_majority_time_ignores_malformed_and_nonfinite_timestamps():
+def test_chain_majority_time_ignores_malformed_and_nonfinite_timestamps() -> None:
     chain = [
         _event("valid-a", 10.0),
         _event("bad-text", "not-a-timestamp"),
@@ -19,12 +21,18 @@ def test_chain_majority_time_ignores_malformed_and_nonfinite_timestamps():
     assert chain_majority_time(chain) == 15.0
 
 
-def test_chain_majority_time_accepts_finite_numeric_strings():
+def test_chain_majority_time_accepts_finite_numeric_strings() -> None:
     chain = [_event("a", "10.5"), _event("b", "20.5")]
 
     assert chain_majority_time(chain) == 15.5
 
 
-def test_future_check_does_not_treat_nonfinite_timestamp_as_valid():
-    assert not is_event_too_future(_event("a", float("nan")), chain_time=100.0)
-    assert not is_event_too_future(_event("a", float("inf")), chain_time=100.0)
+def test_future_check_fails_closed_for_invalid_timestamps() -> None:
+    assert is_event_too_future(_event("bad-text", "not-a-timestamp"), chain_time=100.0)
+    assert is_event_too_future(_event("bad-nan", float("nan")), chain_time=100.0)
+    assert is_event_too_future(_event("bad-inf", float("inf")), chain_time=100.0)
+
+
+def test_future_check_preserves_valid_timestamp_behavior() -> None:
+    assert not is_event_too_future(_event("near", 110.0), chain_time=100.0)
+    assert is_event_too_future(_event("far", 10_000.0), chain_time=100.0)

--- a/backend/services/infonet/tests/test_time_validity_invalid_timestamps.py
+++ b/backend/services/infonet/tests/test_time_validity_invalid_timestamps.py
@@ -1,0 +1,30 @@
+"""Regression coverage for malformed chain timestamps."""
+
+from services.infonet.time_validity import chain_majority_time, is_event_too_future
+
+
+def _event(node_id: str, timestamp):
+    return {"node_id": node_id, "timestamp": timestamp}
+
+
+def test_chain_majority_time_ignores_malformed_and_nonfinite_timestamps():
+    chain = [
+        _event("valid-a", 10.0),
+        _event("bad-text", "not-a-timestamp"),
+        _event("bad-nan", float("nan")),
+        _event("bad-inf", float("inf")),
+        _event("valid-b", 20.0),
+    ]
+
+    assert chain_majority_time(chain) == 15.0
+
+
+def test_chain_majority_time_accepts_finite_numeric_strings():
+    chain = [_event("a", "10.5"), _event("b", "20.5")]
+
+    assert chain_majority_time(chain) == 15.5
+
+
+def test_future_check_does_not_treat_nonfinite_timestamp_as_valid():
+    assert not is_event_too_future(_event("a", float("nan")), chain_time=100.0)
+    assert not is_event_too_future(_event("a", float("inf")), chain_time=100.0)

--- a/backend/services/infonet/time_validity.py
+++ b/backend/services/infonet/time_validity.py
@@ -33,6 +33,7 @@ responsibility.
 
 from __future__ import annotations
 
+import math
 import statistics
 from typing import Any, Iterable
 
@@ -45,6 +46,17 @@ from services.infonet.config import CONFIG
 # Byzantine arithmetic with up to ~5 colluding nodes (median is robust).
 # Configurable for tests.
 _DEFAULT_MEDIAN_N = 11
+
+
+def _finite_timestamp(value: Any) -> float | None:
+    """Return a finite numeric timestamp, or ``None`` when unusable."""
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(timestamp):
+        return None
+    return timestamp
 
 
 def chain_majority_time(
@@ -64,22 +76,27 @@ def chain_majority_time(
     """
     if n <= 0:
         raise ValueError("n must be positive")
-    events = [e for e in chain if isinstance(e, dict)]
-    events.sort(key=lambda e: float(e.get("timestamp") or 0.0), reverse=True)
+
+    events: list[tuple[float, dict[str, Any]]] = []
+    for event in chain:
+        if not isinstance(event, dict):
+            continue
+        timestamp = _finite_timestamp(event.get("timestamp"))
+        if timestamp is None:
+            continue
+        events.append((timestamp, event))
+    events.sort(key=lambda item: item[0], reverse=True)
+
     seen_nodes: set[str] = set()
     timestamps: list[float] = []
-    for ev in events:
-        node = ev.get("node_id")
+    for timestamp, event in events:
+        node = event.get("node_id")
         if not isinstance(node, str) or not node:
             continue
         if node in seen_nodes:
             continue
         seen_nodes.add(node)
-        ts = ev.get("timestamp")
-        try:
-            timestamps.append(float(ts))
-        except (TypeError, ValueError):
-            continue
+        timestamps.append(timestamp)
         if len(timestamps) >= n:
             break
     if not timestamps:
@@ -104,12 +121,10 @@ def is_event_too_future(
         if chain is None:
             raise ValueError("Pass chain or chain_time")
         chain_time = chain_majority_time(chain)
-    try:
-        ts = float(event.get("timestamp"))
-    except (TypeError, ValueError):
-        # Non-numeric timestamp is its own validation failure — let the
-        # schema-level check catch that. Drift check itself returns
-        # False here (we cannot meaningfully compare).
+    ts = _finite_timestamp(event.get("timestamp"))
+    if ts is None:
+        # Non-numeric or non-finite timestamps are their own validation
+        # failure. Drift checking cannot meaningfully compare them.
         return False
     drift = float(CONFIG["max_future_event_drift_sec"])
     return ts > chain_time + drift

--- a/backend/services/infonet/time_validity.py
+++ b/backend/services/infonet/time_validity.py
@@ -110,12 +110,15 @@ def is_event_too_future(
     *,
     chain_time: float | None = None,
 ) -> bool:
-    """Is ``event.timestamp`` more than ``max_future_event_drift_sec``
-    ahead of ``chain_majority_time``?
+    """Is ``event.timestamp`` invalid or beyond allowed future drift?
 
     Pass ``chain_time`` when the caller has already computed it (e.g.
     bulk validation of a batch — avoids recomputing the median per
     event). Otherwise pass ``chain``.
+
+    Invalid/non-finite event timestamps fail closed: they return
+    ``True`` so callers reject or re-queue them rather than allowing
+    malformed events through the drift gate.
     """
     if chain_time is None:
         if chain is None:
@@ -123,9 +126,7 @@ def is_event_too_future(
         chain_time = chain_majority_time(chain)
     ts = _finite_timestamp(event.get("timestamp"))
     if ts is None:
-        # Non-numeric or non-finite timestamps are their own validation
-        # failure. Drift checking cannot meaningfully compare them.
-        return False
+        return True
     drift = float(CONFIG["max_future_event_drift_sec"])
     return ts > chain_time + drift
 


### PR DESCRIPTION
## Summary

- ignore malformed, NaN, and infinite event timestamps when computing chain-majority time
- sort only validated finite timestamps for the median calculation
- keep finite numeric-string timestamps working
- make future-drift validation fail closed for malformed/non-finite event timestamps
- add focused regression coverage for invalid and valid timestamp paths

## Why

One malformed timestamp could previously raise during majority-time sorting, while NaN/Infinity could enter the median. The first version of this fix made invalid timestamps benign in `is_event_too_future()`, which could allow them through when no universal schema guard had rejected them yet.

The revised drift check returns `True` for malformed/non-finite event timestamps, so callers reject or re-queue them, while majority-time calculation continues to exclude those values.

## Test plan

- regression tests in `backend/services/infonet/tests/test_time_validity_invalid_timestamps.py`
- upstream CI

Valid finite chain timestamps and the majority-time rule are unchanged.