### PR TITLE
fix(xquik): respect outage backoff and credential rotation

### DIFF
--- a/backend/services/fetchers/xquik_news.py
+++ b/backend/services/fetchers/xquik_news.py
@@ -28,7 +28,7 @@ _cache_lock = threading.Lock()
 _cache_signature: tuple[str, int] | None = None
 _cache_entries: list[dict[str, Any]] = []
 _attempt_signature: tuple[str, int, str] | None = None
-_last_attempt_at = 0.0
+_last_attempt_at: float | None = None
 
 
 def xquik_fetch_enabled() -> bool:
@@ -159,7 +159,7 @@ def fetch_xquik_entries() -> list[dict[str, Any]]:
         now = time.monotonic()
         if (
             _attempt_signature == attempt_signature
-            and _last_attempt_at
+            and _last_attempt_at is not None
             and now - _last_attempt_at < interval_seconds
         ):
             if _cache_signature == cache_signature:
@@ -188,4 +188,4 @@ def _reset_cache_for_tests() -> None:
         _cache_signature = None
         _cache_entries = []
         _attempt_signature = None
-        _last_attempt_at = 0.0
+        _last_attempt_at = None

--- a/backend/services/fetchers/xquik_news.py
+++ b/backend/services/fetchers/xquik_news.py
@@ -27,7 +27,6 @@ _MAX_TEXT_LENGTH = 500
 _cache_lock = threading.Lock()
 _cache_signature: tuple[str, int] | None = None
 _cache_entries: list[dict[str, Any]] = []
-_cache_fetched_at = 0.0
 _attempt_signature: tuple[str, int, str] | None = None
 _last_attempt_at = 0.0
 
@@ -154,7 +153,7 @@ def fetch_xquik_entries() -> list[dict[str, Any]]:
     cache_signature = (query, limit)
     attempt_signature = (query, limit, _credential_fingerprint(api_key))
 
-    global _cache_entries, _cache_fetched_at, _cache_signature
+    global _cache_entries, _cache_signature
     global _attempt_signature, _last_attempt_at
     with _cache_lock:
         now = time.monotonic()
@@ -177,18 +176,16 @@ def fetch_xquik_entries() -> list[dict[str, Any]]:
         if entries is not None:
             _cache_signature = cache_signature
             _cache_entries = entries
-            _cache_fetched_at = now
         if _cache_signature == cache_signature:
             return [dict(entry) for entry in _cache_entries]
         return []
 
 
 def _reset_cache_for_tests() -> None:
-    global _cache_entries, _cache_fetched_at, _cache_signature
+    global _cache_entries, _cache_signature
     global _attempt_signature, _last_attempt_at
     with _cache_lock:
         _cache_signature = None
         _cache_entries = []
-        _cache_fetched_at = 0.0
         _attempt_signature = None
         _last_attempt_at = 0.0

--- a/backend/services/fetchers/xquik_news.py
+++ b/backend/services/fetchers/xquik_news.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
@@ -27,6 +28,8 @@ _cache_lock = threading.Lock()
 _cache_signature: tuple[str, int] | None = None
 _cache_entries: list[dict[str, Any]] = []
 _cache_fetched_at = 0.0
+_attempt_signature: tuple[str, int, str] | None = None
+_last_attempt_at = 0.0
 
 
 def xquik_fetch_enabled() -> bool:
@@ -63,13 +66,22 @@ def _normalize_tweet(tweet: object) -> dict[str, Any] | None:
     if not isinstance(tweet, dict):
         return None
     tweet_id = str(tweet.get("id") or "").strip()
-    text = " ".join(str(tweet.get("text") or "").split())
+    raw_text = tweet.get("text")
     author = tweet.get("author")
     username = str(author.get("username") or "").strip() if isinstance(author, dict) else ""
-    if not _TWEET_ID_RE.fullmatch(tweet_id) or not _USERNAME_RE.fullmatch(username) or not text:
+    created_at = tweet.get("createdAt")
+    if (
+        not _TWEET_ID_RE.fullmatch(tweet_id)
+        or not _USERNAME_RE.fullmatch(username)
+        or not isinstance(raw_text, str)
+        or not isinstance(created_at, str)
+    ):
         return None
 
-    created_at = tweet.get("createdAt")
+    text = " ".join(raw_text.split())
+    created_at = created_at.strip()
+    if not text:
+        return None
     published_parts = _published_parts(created_at)
     if published_parts is None:
         return None
@@ -121,6 +133,11 @@ def _request_entries(api_key: str, query: str, limit: int) -> list[dict[str, Any
     return entries
 
 
+def _credential_fingerprint(api_key: str) -> str:
+    """Return a non-secret cache key so credential rotation retries immediately."""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+
+
 def fetch_xquik_entries() -> list[dict[str, Any]]:
     """Return cached, normalized X posts for the configured search query."""
     if not xquik_fetch_enabled():
@@ -134,30 +151,44 @@ def fetch_xquik_entries() -> list[dict[str, Any]]:
 
     limit = _bounded_int("XQUIK_SEARCH_LIMIT", 20, 1, _MAX_RESULTS)
     interval_seconds = _bounded_int("XQUIK_SEARCH_INTERVAL_MINUTES", 30, 5, 1440) * 60
-    signature = (query, limit)
+    cache_signature = (query, limit)
+    attempt_signature = (query, limit, _credential_fingerprint(api_key))
 
     global _cache_entries, _cache_fetched_at, _cache_signature
+    global _attempt_signature, _last_attempt_at
     with _cache_lock:
+        now = time.monotonic()
         if (
-            _cache_signature == signature
-            and _cache_fetched_at
-            and time.monotonic() - _cache_fetched_at < interval_seconds
+            _attempt_signature == attempt_signature
+            and _last_attempt_at
+            and now - _last_attempt_at < interval_seconds
         ):
-            return [dict(entry) for entry in _cache_entries]
+            if _cache_signature == cache_signature:
+                return [dict(entry) for entry in _cache_entries]
+            return []
+
+        # Record every outbound attempt, not only successes. This keeps an
+        # unhealthy provider from being retried by the 5-minute news scheduler
+        # more frequently than the operator-configured Xquik interval.
+        _attempt_signature = attempt_signature
+        _last_attempt_at = now
 
         entries = _request_entries(api_key, query, limit)
         if entries is not None:
-            _cache_signature = signature
+            _cache_signature = cache_signature
             _cache_entries = entries
-            _cache_fetched_at = time.monotonic()
-        if _cache_signature == signature:
+            _cache_fetched_at = now
+        if _cache_signature == cache_signature:
             return [dict(entry) for entry in _cache_entries]
         return []
 
 
 def _reset_cache_for_tests() -> None:
     global _cache_entries, _cache_fetched_at, _cache_signature
+    global _attempt_signature, _last_attempt_at
     with _cache_lock:
         _cache_signature = None
         _cache_entries = []
         _cache_fetched_at = 0.0
+        _attempt_signature = None
+        _last_attempt_at = 0.0

--- a/backend/tests/test_xquik_news.py
+++ b/backend/tests/test_xquik_news.py
@@ -93,6 +93,8 @@ def test_request_is_bounded_and_normalizes_untrusted_posts(monkeypatch) -> None:
                     _tweet(tweet_id="9876543210", username="invalid-name"),
                     {**_tweet(tweet_id="111"), "createdAt": "not-a-date"},
                     {"id": "42", "text": "", "author": {"username": "empty"}},
+                    {**_tweet(tweet_id="222"), "text": {"unexpected": "shape"}},
+                    {**_tweet(tweet_id="333"), "createdAt": 1234567890},
                     "not-an-object",
                 ]
             }
@@ -139,7 +141,7 @@ def test_successful_results_are_cached_and_copied(monkeypatch) -> None:
     assert second[0]["title"] == "Missile strike reported in Kyiv"
 
 
-def test_http_failure_keeps_cached_results_without_retry(monkeypatch) -> None:
+def test_http_failure_keeps_cached_results_and_respects_poll_interval(monkeypatch) -> None:
     _enable(monkeypatch)
     responses = [_Response({"tweets": [_tweet()]}), _Response({}, status_code=429)]
     calls = 0
@@ -150,11 +152,48 @@ def test_http_failure_keeps_cached_results_without_retry(monkeypatch) -> None:
         return responses.pop(0)
 
     monkeypatch.setattr(xquik_news.requests, "get", fake_get)
-    clock = iter((1000.0, 2801.0))
+    clock = iter((1000.0, 2801.0, 2802.0))
     monkeypatch.setattr(xquik_news.time, "monotonic", lambda: next(clock))
-    expected = xquik_news.fetch_xquik_entries()
 
+    expected = xquik_news.fetch_xquik_entries()
     assert xquik_news.fetch_xquik_entries() == expected
+    assert xquik_news.fetch_xquik_entries() == expected
+    assert calls == 2
+
+
+def test_failure_without_cache_is_throttled(monkeypatch) -> None:
+    _enable(monkeypatch)
+    calls = 0
+
+    def fake_get(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _Response({}, status_code=503)
+
+    monkeypatch.setattr(xquik_news.requests, "get", fake_get)
+    clock = iter((1000.0, 1001.0))
+    monkeypatch.setattr(xquik_news.time, "monotonic", lambda: next(clock))
+
+    assert xquik_news.fetch_xquik_entries() == []
+    assert xquik_news.fetch_xquik_entries() == []
+    assert calls == 1
+
+
+def test_api_key_rotation_bypasses_failed_attempt_backoff(monkeypatch) -> None:
+    _enable(monkeypatch)
+    responses = [_Response({}, status_code=401), _Response({"tweets": [_tweet()]})]
+    calls = 0
+
+    def fake_get(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return responses.pop(0)
+
+    monkeypatch.setattr(xquik_news.requests, "get", fake_get)
+
+    assert xquik_news.fetch_xquik_entries() == []
+    monkeypatch.setenv("XQUIK_API_KEY", "rotated-unit-test-key")
+    assert len(xquik_news.fetch_xquik_entries()) == 1
     assert calls == 2
 
 
@@ -162,7 +201,9 @@ def test_failed_query_change_does_not_reuse_another_query(monkeypatch) -> None:
     _enable(monkeypatch)
     responses = [_Response({"tweets": [_tweet()]}), _Response({}, status_code=503)]
     monkeypatch.setattr(
-        xquik_news.requests, "get", lambda *args, **kwargs: responses.pop(0)
+        xquik_news.requests,
+        "get",
+        lambda *args, **kwargs: responses.pop(0),
     )
     assert len(xquik_news.fetch_xquik_entries()) == 1
 
@@ -176,6 +217,7 @@ def test_redirect_and_invalid_json_fail_closed(monkeypatch) -> None:
 
     monkeypatch.setattr(xquik_news.requests, "get", lambda *args, **kwargs: responses.pop(0))
     assert xquik_news.fetch_xquik_entries() == []
+    monkeypatch.setenv("XQUIK_SEARCH_QUERY", "different region")
     assert xquik_news.fetch_xquik_entries() == []
 
 


### PR DESCRIPTION
## Summary

Follow-up hardening for the opt-in Xquik news source merged in #530.

- Respect `XQUIK_SEARCH_INTERVAL_MINUTES` after failed provider attempts, not only successful polls.
- Prevent Shadowbroker's 5-minute news scheduler from hammering an unhealthy/rate-limited Xquik endpoint every cycle.
- Keep same-query cached results available during an outage while suppressing redundant outbound requests.
- Retry immediately when the operator changes the query, result limit, or API key; API-key identity is represented only by a short SHA-256 fingerprint in memory, never logged.
- Reject malformed Xquik records whose `text` or `createdAt` fields are not strings instead of stringifying unexpected upstream objects.

## UX / compatibility

- Xquik remains completely opt-in and default-off.
- RSS/news behavior is unchanged when Xquik is disabled or unavailable.
- No frontend changes, prompts, new dependencies, InfoNet/store changes, or paid-service requirement changes.
- Operators fixing a bad/expired Xquik key do not have to wait for the previous backoff window.

## Regression coverage

`backend/tests/test_xquik_news.py` now covers:

- cached-results behavior across a 429/outage;
- no-cache failure throttling;
- immediate retry after API-key rotation;
- immediate isolation/retry when the search query changes;
- redirects and invalid JSON still fail closed;
- malformed non-string text/timestamp payloads are rejected.

## Validation

The PR is intentionally narrow: 2 files only, based exactly on the #530 merge head (`9dc95833782952ac3dcbfd56cfbdf761daeaf5f0`).

Fresh checks on head `b06adeab4624fe95074ece3480f5de604e160353`:

- ✅ CI - Lint & Test #642
  - secret scan
  - Ruff
  - Black check
  - import smoke check
  - backend release smoke suite including `test_xquik_news.py`
  - frontend lint/format/Vitest/production build/bundle report
- ✅ Docker Publish #797
  - backend amd64
  - backend arm64
  - frontend amd64
  - frontend arm64

The existing Xquik request bounds, no-redirect credential handling, cache isolation, and default-off behavior remain intact.