### PR TITLE
feat: add dormant QazLake compare client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,9 @@ ADMIN_KEY=
 # MESH_SYNC_TIMEOUT_S=5
 # MESH_SYNC_MAX_PEERS_PER_CYCLE=3
 # MESH_BOOTSTRAP_SEED_FAILURE_COOLDOWN_S=15
+# Mesh HMAC credentials must come from protected environment or *_FILE secrets.
+# MESH_PEER_PUSH_SECRET=
+# MESH_PEER_PUSH_SECRET_PREVIOUS= # receive-only during rolling rotation; clear afterwards
 
 # Google Earth Engine for VIIRS night lights change detection (optional).
 # pip install earthengine-api
@@ -149,6 +152,16 @@ ADMIN_KEY=
 
 # Override the backend URL the frontend uses (leave blank for auto-detect)
 # NEXT_PUBLIC_API_URL=http://192.168.1.50:8000
+
+# QazPipe/QazLake source convergence. Empty modes keep every source local.
+# Switch one family to "compare" first; use "qazpipe" only after accepted
+# comparison receipts and after the matching QazPipe schedule is active.
+# QAZLAKE_SHADOW_FEED_URL=https://qazlake.example.internal
+# QAZLAKE_SHADOW_FEED_TOKEN_FILE=/run/secrets/qazlake_shadow_feed_token
+# SHADOW_LAYER_SOURCE_MODES={"geohazards":"compare"}
+# SHADOW_QAZLAKE_CACHE_PATH=/app/data/qazlake_shadow_cache.json
+# SHADOW_QAZPIPE_COMPARE_RECEIPT_PATH=/app/data/qazpipe_compare_receipts.jsonl
+# QAZLAKE_SHADOW_POLL_INTERVAL_S=30
 
 # ── Mesh / Reticulum (RNS) ─────────────────────────────────────
 # MESH_RNS_ENABLED=false

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -264,6 +264,7 @@ AIS_API_KEY=              # https://aisstream.io/ — free tier WebSocket key
 # MESH_DEFAULT_SYNC_PEERS=         # legacy alias; prefer MESH_BOOTSTRAP_SEED_PEERS
 # MESH_RELAY_PEERS=               # comma-separated operator-trusted sync/push peers (empty by default)
 # MESH_PEER_PUSH_SECRET=          # REQUIRED when relay/RNS peers are configured (min 16 chars, generate with: python -c "import secrets; print(secrets.token_urlsafe(32))")
+# MESH_PEER_PUSH_SECRET_PREVIOUS= # TEMPORARY receive-only fallback during rolling rotation; clear after every peer uses primary
 # MESH_SYNC_INTERVAL_S=300
 # MESH_SYNC_FAILURE_BACKOFF_S=60
 #

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -45,7 +45,7 @@ from services.mesh.mesh_compatibility import (
 from services.mesh.mesh_crypto import (
     _derive_peer_key,
     normalize_peer_url,
-    resolve_peer_key_for_url,
+    resolve_peer_key_candidates_for_url,
     verify_signature,
     verify_node_binding,
     parse_public_key_algo,
@@ -513,8 +513,11 @@ async def require_openclaw_or_local(request: Request):
 # Startup validators
 # ---------------------------------------------------------------------------
 
-_KNOWN_COMPROMISED_PEER_PUSH_SECRET_SHA256 = (
-    "be05bc75350d6e5d2e154e969c4dfc14bab1e48a9661c64ab7a331e0aa96aea7"
+_KNOWN_COMPROMISED_PEER_PUSH_SECRET_SHA256 = frozenset(
+    {
+        "be05bc75350d6e5d2e154e969c4dfc14bab1e48a9661c64ab7a331e0aa96aea7",
+        "d4a7406f20b988a723afc56e923d520e7174370140fa0eb2388cfd2691fd202c",
+    }
 )
 
 
@@ -569,32 +572,11 @@ def _validate_insecure_admin_startup() -> None:
         sys.exit(1)
 
 
-def _auto_generate_peer_push_secret() -> str | None:
-    """Generate a strong peer push secret, persist to .env, return it."""
-    import secrets
-
-    new_secret = secrets.token_urlsafe(32)  # 43-char URL-safe string
-    try:
-        from routers.ai_intel import _write_env_value
-
-        _write_env_value("MESH_PEER_PUSH_SECRET", new_secret)
-        os.environ["MESH_PEER_PUSH_SECRET"] = new_secret
-        try:
-            get_settings.cache_clear()
-        except Exception:
-            pass
-        return new_secret
-    except Exception as exc:
-        logger.warning("Could not auto-generate MESH_PEER_PUSH_SECRET: %s", exc)
-        return None
-
-
 def _validate_peer_push_secret() -> None:
     """Ensure peer push authentication is properly configured.
 
-    Instead of refusing to start when the secret is missing or compromised,
-    auto-generate a strong replacement and persist it to .env.  The only
-    hard failure is if auto-generation itself fails AND peers are configured.
+    Mesh credentials are operator-managed protected configuration. Never write
+    them into the checkout or generate a silent replacement during startup.
     """
     settings = None
     try:
@@ -603,35 +585,34 @@ def _validate_peer_push_secret() -> None:
     except Exception:
         secret = os.environ.get("MESH_PEER_PUSH_SECRET", "").strip()
 
-    # Replace the known-compromised testnet default automatically
     if (
         secret
         and _hashlib_mod.sha256(secret.encode("utf-8")).hexdigest()
-        == _KNOWN_COMPROMISED_PEER_PUSH_SECRET_SHA256
+        in _KNOWN_COMPROMISED_PEER_PUSH_SECRET_SHA256
     ):
-        logger.warning(
-            "MESH_PEER_PUSH_SECRET was the publicly-known testnet default — "
-            "auto-generating a secure replacement."
+        logger.critical(
+            "MESH_PEER_PUSH_SECRET is a known compromised value. Refusing to "
+            "start; inject a rotated secret through protected configuration."
         )
-        new_secret = _auto_generate_peer_push_secret()
-        if new_secret:
-            secret = new_secret
-            logger.info("MESH_PEER_PUSH_SECRET replaced and saved to .env.")
-        else:
-            logger.critical(
-                "MESH_PEER_PUSH_SECRET is the publicly-known testnet default "
-                "and could not be replaced automatically. "
-                "Set a unique secret in your .env file."
-            )
-            sys.exit(1)
+        sys.exit(1)
+
+    def invalid_secret_reason(value: str) -> str:
+        raw = str(value or "").strip()
+        if not raw:
+            return "empty"
+        if raw.lower() in {"change-me", "changeme"}:
+            return "placeholder"
+        if len(raw) < 16:
+            return "too short"
+        return ""
 
     try:
         from services.env_check import (
-            _invalid_peer_push_secret_reason,
+            _invalid_peer_push_secret_reason as invalid_secret_reason,
             _peer_push_secret_required,
         )
 
-        secret_reason = _invalid_peer_push_secret_reason(secret)
+        secret_reason = invalid_secret_reason(secret)
         secret_required = (
             _peer_push_secret_required(settings)
             if settings is not None
@@ -645,29 +626,38 @@ def _validate_peer_push_secret() -> None:
         secret_reason = ""
         secret_required = False
 
-    # Secret is required but invalid — try to auto-fix
-    if secret_required and secret_reason:
-        logger.warning(
-            "MESH_PEER_PUSH_SECRET is invalid (%s) while relay or RNS peers are "
-            "configured — auto-generating a secure replacement.",
-            secret_reason,
-        )
-        new_secret = _auto_generate_peer_push_secret()
-        if new_secret:
-            logger.info("MESH_PEER_PUSH_SECRET auto-generated and saved to .env.")
-        else:
+    previous_value = (
+        getattr(settings, "MESH_PEER_PUSH_SECRET_PREVIOUS", "")
+        if settings is not None
+        else os.environ.get("MESH_PEER_PUSH_SECRET_PREVIOUS", "")
+    )
+    previous_secret = previous_value.strip() if isinstance(previous_value, str) else ""
+    if previous_secret:
+        previous_hash = _hashlib_mod.sha256(previous_secret.encode("utf-8")).hexdigest()
+        previous_reason = invalid_secret_reason(previous_secret)
+        if previous_hash in _KNOWN_COMPROMISED_PEER_PUSH_SECRET_SHA256:
+            previous_reason = "known compromised value"
+        if previous_reason or previous_secret == secret:
             logger.critical(
-                "MESH_PEER_PUSH_SECRET is invalid (%s) and could not be replaced "
-                "automatically. Set a unique secret of at least 16 characters in .env.",
-                secret_reason,
+                "MESH_PEER_PUSH_SECRET_PREVIOUS is invalid (%s). Refusing to start; "
+                "the rotation fallback must be strong, distinct, and uncompromised.",
+                previous_reason or "same as primary",
             )
             sys.exit(1)
-        return
+
+    if secret_required and secret_reason:
+        logger.critical(
+            "MESH_PEER_PUSH_SECRET is invalid (%s) while relay or RNS peers are "
+            "configured. Refusing to start; inject a unique secret of at least "
+            "16 characters through protected configuration.",
+            secret_reason,
+        )
+        sys.exit(1)
 
     if not secret:
         logger.warning(
             "MESH_PEER_PUSH_SECRET is not set — peer push authentication is disabled. "
-            "Set MESH_PEER_PUSH_SECRET in your .env file for production use."
+            "Inject MESH_PEER_PUSH_SECRET through protected configuration for production use."
         )
 
 
@@ -1415,27 +1405,28 @@ def _verify_peer_transport_hmac(request: Request, body_bytes: bytes) -> bool:
     peer_url = _peer_hmac_url_from_request(request)
     if not peer_url:
         return False
-    peer_key = resolve_peer_key_for_url(peer_url)
-    if not peer_key:
+    peer_keys = resolve_peer_key_candidates_for_url(peer_url)
+    if not peer_keys:
         return False
-
-    expected = _hmac_mod.new(
-        peer_key,
-        body_bytes,
-        _hashlib_mod.sha256,
-    ).hexdigest()
-    return _hmac_mod.compare_digest(provided.lower(), expected.lower())
+    return any(
+        _hmac_mod.compare_digest(
+            provided.lower(),
+            _hmac_mod.new(peer_key, body_bytes, _hashlib_mod.sha256).hexdigest().lower(),
+        )
+        for peer_key in peer_keys
+    )
 
 
 def _verify_peer_push_hmac(request: Request, body_bytes: bytes) -> bool:
     """Verify HMAC-SHA256 peer authentication on push requests.
 
-    Issue #256: ``resolve_peer_key_for_url`` looks up a per-peer secret
+    Issue #256: the key resolver looks up a per-peer secret
     in ``MESH_PEER_SECRETS`` first, then falls back to the global
     ``MESH_PEER_PUSH_SECRET``. When a peer URL is listed in the per-peer
-    map, only the listed secret is accepted for it — the global secret
-    is ignored, so any peer that knows only the global secret cannot
-    forge a request claiming to be that peer.
+    map, only the listed secret is accepted for it — global primary and
+    previous secrets are ignored, so a peer that knows only a global
+    secret cannot forge a request claiming to be that peer. Unmapped
+    peers may use the receive-only previous global secret during rotation.
     """
     provided = str(request.headers.get("x-peer-hmac", "") or "").strip()
     if not provided:
@@ -1445,16 +1436,16 @@ def _verify_peer_push_hmac(request: Request, body_bytes: bytes) -> bool:
     allowed_peers = set(authenticated_push_peer_urls())
     if not peer_url or peer_url not in allowed_peers:
         return False
-    peer_key = resolve_peer_key_for_url(peer_url)
-    if not peer_key:
+    peer_keys = resolve_peer_key_candidates_for_url(peer_url)
+    if not peer_keys:
         return False
-
-    expected = _hmac_mod.new(
-        peer_key,
-        body_bytes,
-        _hashlib_mod.sha256,
-    ).hexdigest()
-    return _hmac_mod.compare_digest(provided.lower(), expected.lower())
+    return any(
+        _hmac_mod.compare_digest(
+            provided.lower(),
+            _hmac_mod.new(peer_key, body_bytes, _hashlib_mod.sha256).hexdigest().lower(),
+        )
+        for peer_key in peer_keys
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/main.py
+++ b/backend/main.py
@@ -177,6 +177,9 @@ _SECRET_VARS = [
     "SHODAN_API_KEY",
     "FINNHUB_API_KEY",
     "MESH_SECURE_STORAGE_SECRET",
+    "MESH_PEER_PUSH_SECRET",
+    "MESH_PEER_PUSH_SECRET_PREVIOUS",
+    "QAZLAKE_SHADOW_FEED_TOKEN",
 ]
 
 for _var in _SECRET_VARS:
@@ -2752,6 +2755,13 @@ async def lifespan(app: FastAPI):
     if _MESH_ONLY:
         logger.info("MESH_ONLY enabled â€” skipping global data fetchers/schedulers.")
     else:
+        from services.qazlake_shadow_feed import (
+            start_shadow_feed_sync,
+            validate_shadow_feed_configuration,
+        )
+
+        validate_shadow_feed_configuration()
+        start_shadow_feed_sync()
         # Start AIS stream first â€” it loads the disk cache (instant ships) then
         # begins accumulating live vessel data via WebSocket in the background.
         start_ais_stream()
@@ -2842,7 +2852,10 @@ async def lifespan(app: FastAPI):
             except Exception as e:
                 logger.warning(f"Route database prime failed (non-fatal): {e}")
 
-        threading.Thread(target=_prime_route_database, daemon=True).start()
+        from services.qazlake_shadow_feed import local_collection_allowed
+
+        if local_collection_allowed("aviation_public"):
+            threading.Thread(target=_prime_route_database, daemon=True).start()
 
         # Prime the OpenSky aircraft metadata DB so hex24 -> aircraft type
         # lookups work on the first flight cycle (and emissions get populated
@@ -2854,7 +2867,8 @@ async def lifespan(app: FastAPI):
             except Exception as e:
                 logger.warning(f"Aircraft database prime failed (non-fatal): {e}")
 
-        threading.Thread(target=_prime_aircraft_database, daemon=True).start()
+        if local_collection_allowed("aviation_public"):
+            threading.Thread(target=_prime_aircraft_database, daemon=True).start()
 
         # Seed cached first-paint layers before accepting requests. This is
         # disk-only and keeps the critical bootstrap endpoint independent from
@@ -2899,6 +2913,9 @@ async def lifespan(app: FastAPI):
         stop_ais_stream()
         stop_scheduler()
         stop_carrier_tracker()
+        from services.qazlake_shadow_feed import stop_shadow_feed_sync
+
+        stop_shadow_feed_sync()
         try:
             from services.aprs_is_bridge import aprs_is_bridge
             from services.sigint_bridge import sigint_grid

--- a/backend/routers/data.py
+++ b/backend/routers/data.py
@@ -97,21 +97,32 @@ def _viewport_changed_enough(bounds: tuple) -> bool:
 
 def _queue_viirs_change_refresh() -> None:
     from services.fetchers.earth_observation import fetch_viirs_change_nodes
+
     threading.Thread(target=fetch_viirs_change_nodes, daemon=True).start()
 
 
 def _etag_response(request: Request, payload: dict, prefix: str = "", default=None):
     etag = _current_etag(prefix)
     if request.headers.get("if-none-match") == etag:
-        return Response(status_code=304, headers={"ETag": etag, "Cache-Control": "no-cache"})
+        return Response(
+            status_code=304, headers={"ETag": etag, "Cache-Control": "no-cache"}
+        )
     content = json_mod.dumps(_json_safe(payload), default=default, allow_nan=False)
-    return Response(content=content, media_type="application/json",
-        headers={"ETag": etag, "Cache-Control": "no-cache"})
+    return Response(
+        content=content,
+        media_type="application/json",
+        headers={"ETag": etag, "Cache-Control": "no-cache"},
+    )
 
 
 def _current_etag(prefix: str = "") -> str:
     from services.fetchers._store import get_active_layers_version, get_data_version
-    return f"{prefix}v{get_data_version()}-l{get_active_layers_version()}"
+    from services.qazlake_shadow_feed import shadow_feed_etag_suffix
+
+    return (
+        f"{prefix}{shadow_feed_etag_suffix()}"
+        f"v{get_data_version()}-l{get_active_layers_version()}"
+    )
 
 
 # ── Issue #288: viewport-aware payloads ─────────────────────────────────────
@@ -669,7 +680,11 @@ async def live_data(request: Request):
     from services.fetchers._store import get_latest_data_refs_snapshot
 
     def _build() -> dict:
-        return get_latest_data_refs_snapshot()
+        from services.qazlake_shadow_feed import apply_layer_source_modes
+
+        return apply_layer_source_modes(
+            get_latest_data_refs_snapshot(), endpoint="live-data"
+        )
 
     return Response(
         content=_cached_live_data_bytes(etag, _build),
@@ -702,45 +717,110 @@ async def bootstrap_critical(request: Request):
 
     def _build() -> dict:
         d = get_latest_data_subset_refs(
-            "last_updated", "commercial_flights", "military_flights", "private_flights",
-            "private_jets", "tracked_flights", "ships", "uavs", "liveuamap", "gps_jamming",
-            "satellites", "satellite_source", "satellite_analysis", "sigint", "sigint_totals",
-            "trains", "news", "gdelt", "airports", "threat_level", "trending_markets",
-            "correlations", "fimi", "crowdthreat",
+            "last_updated",
+            "commercial_flights",
+            "military_flights",
+            "private_flights",
+            "private_jets",
+            "tracked_flights",
+            "ships",
+            "uavs",
+            "liveuamap",
+            "gps_jamming",
+            "satellites",
+            "satellite_source",
+            "satellite_analysis",
+            "sigint",
+            "sigint_totals",
+            "trains",
+            "news",
+            "gdelt",
+            "airports",
+            "threat_level",
+            "trending_markets",
+            "correlations",
+            "fimi",
+            "crowdthreat",
         )
         freshness = get_source_timestamps_snapshot()
-        ships_enabled = any(active_layers.get(key, True) for key in (
-            "ships_military", "ships_cargo", "ships_civilian", "ships_passenger", "ships_tracked_yachts"))
+        ships_enabled = any(
+            active_layers.get(key, True)
+            for key in (
+                "ships_military",
+                "ships_cargo",
+                "ships_civilian",
+                "ships_passenger",
+                "ships_tracked_yachts",
+            )
+        )
         sigint_items = _filter_sigint_by_layers(d.get("sigint") or [], active_layers)
-        return {
+        payload = {
             "last_updated": d.get("last_updated"),
-            "commercial_flights": (d.get("commercial_flights") or []) if active_layers.get("flights", True) else [],
-            "military_flights": (d.get("military_flights") or []) if active_layers.get("military", True) else [],
-            "private_flights": (d.get("private_flights") or []) if active_layers.get("private", True) else [],
-            "private_jets": (d.get("private_jets") or []) if active_layers.get("jets", True) else [],
-            "tracked_flights": (d.get("tracked_flights") or []) if active_layers.get("tracked", True) else [],
+            "commercial_flights": (d.get("commercial_flights") or [])
+            if active_layers.get("flights", True)
+            else [],
+            "military_flights": (d.get("military_flights") or [])
+            if active_layers.get("military", True)
+            else [],
+            "private_flights": (d.get("private_flights") or [])
+            if active_layers.get("private", True)
+            else [],
+            "private_jets": (d.get("private_jets") or [])
+            if active_layers.get("jets", True)
+            else [],
+            "tracked_flights": (d.get("tracked_flights") or [])
+            if active_layers.get("tracked", True)
+            else [],
             "ships": (d.get("ships") or []) if ships_enabled else [],
-            "uavs": (d.get("uavs") or []) if active_layers.get("military", True) else [],
-            "liveuamap": (d.get("liveuamap") or []) if active_layers.get("global_incidents", True) else [],
-            "gps_jamming": (d.get("gps_jamming") or []) if active_layers.get("gps_jamming", True) else [],
-            "satellites": (d.get("satellites") or []) if active_layers.get("satellites", True) else [],
+            "uavs": (d.get("uavs") or [])
+            if active_layers.get("military", True)
+            else [],
+            "liveuamap": (d.get("liveuamap") or [])
+            if active_layers.get("global_incidents", True)
+            else [],
+            "gps_jamming": (d.get("gps_jamming") or [])
+            if active_layers.get("gps_jamming", True)
+            else [],
+            "satellites": (d.get("satellites") or [])
+            if active_layers.get("satellites", True)
+            else [],
             "satellite_source": d.get("satellite_source", "none"),
-            "satellite_analysis": (d.get("satellite_analysis") or {}) if active_layers.get("satellites", True) else {},
-            "sigint": sigint_items if (active_layers.get("sigint_meshtastic", True) or active_layers.get("sigint_aprs", True)) else [],
+            "satellite_analysis": (d.get("satellite_analysis") or {})
+            if active_layers.get("satellites", True)
+            else {},
+            "sigint": sigint_items
+            if (
+                active_layers.get("sigint_meshtastic", True)
+                or active_layers.get("sigint_aprs", True)
+            )
+            else [],
             "sigint_totals": _sigint_totals_for_items(sigint_items),
-            "trains": (d.get("trains") or []) if active_layers.get("trains", True) else [],
+            "trains": (d.get("trains") or [])
+            if active_layers.get("trains", True)
+            else [],
             "news": d.get("news") or [],
-            "gdelt": (d.get("gdelt") or []) if active_layers.get("global_incidents", True) else [],
+            "gdelt": (d.get("gdelt") or [])
+            if active_layers.get("global_incidents", True)
+            else [],
             "airports": d.get("airports") or [],
             "threat_level": d.get("threat_level"),
             "trending_markets": d.get("trending_markets") or [],
-            "correlations": (d.get("correlations") or []) if active_layers.get("correlations", True) else [],
+            "correlations": (d.get("correlations") or [])
+            if active_layers.get("correlations", True)
+            else [],
             "fimi": d.get("fimi"),
-            "crowdthreat": (d.get("crowdthreat") or []) if active_layers.get("crowdthreat", True) else [],
+            "crowdthreat": (d.get("crowdthreat") or [])
+            if active_layers.get("crowdthreat", True)
+            else [],
             "freshness": freshness,
             "bootstrap_ready": True,
             "bootstrap_payload": True,
         }
+        from services.qazlake_shadow_feed import apply_layer_source_modes
+
+        return apply_layer_source_modes(
+            payload, endpoint="bootstrap-critical", enabled_layers=active_layers
+        )
 
     return Response(
         content=_cached_live_data_bytes(etag, _build),
@@ -899,6 +979,12 @@ async def live_data_fast(
 ):
     bbox_suffix = _bbox_etag_suffix(s, w, n, e)
     client_lv = None if initial else _parse_layer_versions(lv)
+    from services.qazlake_shadow_feed import uses_qazpipe_mode
+
+    if uses_qazpipe_mode():
+        # A QazLake watermark is authoritative and does not share the local
+        # store's per-layer delta lineage; serve a compatible full snapshot.
+        client_lv = None
     want_delta = client_lv is not None
 
     if want_delta:
@@ -968,9 +1054,17 @@ async def live_data_fast(
             # Issue #288: bbox densify first so world/continental caps sample
             # the *visible* set, not a random world subset then clip.
             if _has_full_bbox(s, w, n, e):
-                payload = _apply_bbox_to_payload(payload, _FAST_BBOX_HEAVY_KEYS, s, w, n, e)
+                payload = _apply_bbox_to_payload(
+                    payload, _FAST_BBOX_HEAVY_KEYS, s, w, n, e
+                )
             payload = _cap_fast_dashboard_payload(payload, s=s, w=w, n=n, e=e)
-        return _attach_version_meta(payload)
+        from services.qazlake_shadow_feed import apply_layer_source_modes
+
+        return _attach_version_meta(
+            apply_layer_source_modes(
+                payload, endpoint="live-data-fast", enabled_layers=active_layers
+            )
+        )
 
     return Response(
         content=_cached_live_data_bytes(etag, _build),
@@ -1086,7 +1180,11 @@ async def live_data_slow(
         # hides the infrastructure overlay the operator already has on screen.
         if _has_full_bbox(s, w, n, e):
             payload = _apply_bbox_to_payload(payload, _SLOW_BBOX_HEAVY_KEYS, s, w, n, e)
-        return payload
+        from services.qazlake_shadow_feed import apply_layer_source_modes
+
+        return apply_layer_source_modes(
+            payload, endpoint="live-data-slow", enabled_layers=active_layers
+        )
 
     return Response(
         content=_cached_live_data_bytes(etag, _build),

--- a/backend/services/config.py
+++ b/backend/services/config.py
@@ -56,7 +56,8 @@ class Settings(BaseSettings):
         "ul1d0kj/ODPIp0OhHzX8eLAVXzJ3CVvzW1vn2IC6q3I="
     )
     MESH_BOOTSTRAP_SIGNER_PRIVATE_KEY: str = ""
-    # When true, empty MESH_PEER_PUSH_SECRET uses the public fleet HMAC for seed join/announce.
+    # Fleet discovery never supplies transport credentials. Operators must inject
+    # MESH_PEER_PUSH_SECRET through protected environment when peer auth is enabled.
     MESH_INFONET_FLEET_JOIN: bool = True
     MESH_INFONET_FLEET_JOIN_DISABLED: bool = False
     # Headless relay/seed compose: auto-enable Tor wormhole on startup so
@@ -79,6 +80,9 @@ class Settings(BaseSettings):
     MESH_RELAY_FAILURE_COOLDOWN_S: int = 120
     MESH_BOOTSTRAP_SEED_FAILURE_COOLDOWN_S: int = 15
     MESH_PEER_PUSH_SECRET: str = ""
+    # Temporary receive-only fallback for rolling rotation. Outbound requests are
+    # always signed with MESH_PEER_PUSH_SECRET. Remove this after every node has moved.
+    MESH_PEER_PUSH_SECRET_PREVIOUS: str = ""
     # Issue #256 (tg12): optional per-peer HMAC secret map. Comma-separated
     # `url=secret` pairs. When a peer URL appears here, only that per-peer
     # secret is accepted for it — the global MESH_PEER_PUSH_SECRET above is

--- a/backend/services/data_fetcher.py
+++ b/backend/services/data_fetcher.py
@@ -109,6 +109,59 @@ from services.scm.suppliers import fetch_scm_suppliers  # noqa: F401
 from services.ais_stream import prune_stale_vessels  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+# Provider-neutral recurring collection families owned by QazPipe after their
+# explicit family mode is switched to ``qazpipe``.  Compare mode deliberately
+# leaves the local collector running so receipts have a real baseline.
+_PUBLIC_COLLECTOR_FAMILY_BY_NAME = {
+    "fetch_flights": "aviation_public",
+    "fetch_military_flights": "aviation_public",
+    "refresh_route_database": "aviation_public",
+    "refresh_aircraft_database": "aviation_public",
+    "fetch_satellites": "orbital_public",
+    "fetch_satnogs": "orbital_public",
+    "fetch_tinygs": "orbital_public",
+    "fetch_earthquakes": "geohazards",
+    "fetch_volcanoes": "geohazards",
+    "fetch_weather": "weather_environment",
+    "fetch_space_weather": "weather_environment",
+    "fetch_weather_alerts": "weather_environment",
+    "fetch_air_quality": "weather_environment",
+    "fetch_uap_sightings": "uap_public",
+    "fetch_internet_outages": "network_observability",
+    "fetch_ripe_atlas_probes": "network_observability",
+    "fetch_news": "events_media",
+    "fetch_gdelt": "events_media",
+    "fetch_telegram_osint": "events_media",
+    "fetch_kiwisdr": "radio_public",
+    "fetch_psk_reporter": "radio_public",
+    "fetch_cctv": "visual_reference",
+    "fetch_sar_catalog": "visual_reference",
+    "fetch_cyber_threats": "cyber_public",
+    "fetch_trains": "transport_public",
+    "fetch_datacenters": "infrastructure_public",
+    "fetch_power_plants": "infrastructure_public",
+}
+
+
+def _local_collector_allowed(func) -> bool:
+    family = _PUBLIC_COLLECTOR_FAMILY_BY_NAME.get(getattr(func, "__name__", ""))
+    if not family:
+        return True
+    from services.qazlake_shadow_feed import local_collection_allowed
+
+    allowed = local_collection_allowed(family)
+    if not allowed:
+        logger.info(
+            "Local collector suppressed after QazPipe cutover: %s", func.__name__
+        )
+    return allowed
+
+
+def _eligible_collectors(funcs):
+    return [func for func in funcs if _local_collector_allowed(func)]
+
+
 _SLOW_FETCH_S = float(os.environ.get("FETCH_SLOW_THRESHOLD_S", "5"))
 # Hard wall-clock limit per individual fetch task.  A task that exceeds this
 # is treated as a failure so it cannot block an entire fetch tier indefinitely.
@@ -450,7 +503,7 @@ def update_fast_data():
         fetch_sigint,
         fetch_trains,
     ]
-    _run_tasks("fast-tier", fast_funcs)
+    _run_tasks("fast-tier", _eligible_collectors(fast_funcs))
     with _data_lock:
         latest_data["last_updated"] = datetime.utcnow().isoformat()
     from services.fetchers._store import bump_data_version
@@ -489,7 +542,7 @@ def update_slow_data():
         fetch_cyber_threats,
         fetch_scm_suppliers,
     ]
-    _run_tasks("slow-tier", slow_funcs)
+    _run_tasks("slow-tier", _eligible_collectors(slow_funcs))
     # Run correlation engine after all data is fresh (skip when overlay is off).
     try:
         from services.fetchers._store import is_any_active
@@ -534,6 +587,8 @@ def _record_fetch_failure(label: str, name: str, start: float, error: Exception)
 
 def _load_cctv_cache_for_startup() -> None:
     """Load cached CCTV rows without running remote ingestors during first paint."""
+    if not _local_collector_allowed(fetch_cctv):
+        return
     try:
         fetch_cctv()
     except Exception as e:
@@ -542,7 +597,9 @@ def _load_cctv_cache_for_startup() -> None:
 
 def _load_static_infrastructure_for_startup() -> None:
     """Disk-backed reference layers — instant, no network."""
-    for func in (fetch_datacenters, fetch_military_bases, fetch_power_plants):
+    for func in _eligible_collectors(
+        (fetch_datacenters, fetch_military_bases, fetch_power_plants)
+    ):
         try:
             func()
         except Exception as e:
@@ -556,21 +613,25 @@ def _run_delayed_startup_heavy_refresh() -> None:
             _STARTUP_HEAVY_REFRESH_DELAY_S,
         )
         time.sleep(_STARTUP_HEAVY_REFRESH_DELAY_S)
-    logger.info("Startup heavy synthesis beginning (slow feeds, enrichment, daily products)...")
+    logger.info(
+        "Startup heavy synthesis beginning (slow feeds, enrichment, daily products)..."
+    )
     _run_tasks(
         "startup-heavy",
-        [
-            update_slow_data,
-            fetch_telegram_osint,
-            fetch_volcanoes,
-            fetch_viirs_change_nodes,
-            fetch_unusual_whales,
-            fetch_fimi,
-            fetch_uap_sightings,
-            fetch_wastewater,
-            fetch_sar_catalog,
-            fetch_sar_products,
-        ],
+        _eligible_collectors(
+            [
+                update_slow_data,
+                fetch_telegram_osint,
+                fetch_volcanoes,
+                fetch_viirs_change_nodes,
+                fetch_unusual_whales,
+                fetch_fimi,
+                fetch_uap_sightings,
+                fetch_wastewater,
+                fetch_sar_catalog,
+                fetch_sar_products,
+            ]
+        ),
     )
     logger.info("Startup heavy synthesis complete.")
 
@@ -605,15 +666,17 @@ def update_all_data(*, startup_mode: bool = False):
         meshtastic_seeded = bool(latest_data.get("meshtastic_map_nodes"))
     if startup_mode:
         _load_cctv_cache_for_startup()
-        priority_funcs = [
-            fetch_airports,
-            update_fast_data,
-            fetch_news,
-            fetch_gdelt,
-            fetch_crowdthreat,
-            fetch_firms_fires,
-            fetch_weather_alerts,
-        ]
+        priority_funcs = _eligible_collectors(
+            [
+                fetch_airports,
+                update_fast_data,
+                fetch_news,
+                fetch_gdelt,
+                fetch_crowdthreat,
+                fetch_firms_fires,
+                fetch_weather_alerts,
+            ]
+        )
         if not meshtastic_seeded:
             priority_funcs.append(fetch_meshtastic_nodes)
         else:
@@ -671,8 +734,14 @@ def update_all_data(*, startup_mode: bool = False):
     if not startup_mode:
         refresh_funcs.append(update_liveuamap)
     else:
-        logger.info("Startup preload: deferring Playwright Liveuamap scraper to scheduled cadence")
-    _run_tasks("full-refresh", refresh_funcs, max_concurrency=_STARTUP_HEAVY_CONCURRENCY)
+        logger.info(
+            "Startup preload: deferring Playwright Liveuamap scraper to scheduled cadence"
+        )
+    _run_tasks(
+        "full-refresh",
+        _eligible_collectors(refresh_funcs),
+        max_concurrency=_STARTUP_HEAVY_CONCURRENCY,
+    )
     # Run CCTV ingest immediately so cameras are available on first request
     # (the scheduled job also runs every 10 min for ongoing refresh).
     if startup_mode:
@@ -795,6 +864,17 @@ def start_scheduler():
     init_db()
     _scheduler = BackgroundScheduler(daemon=True)
 
+    def _add_public_job(family: str, func, trigger: str, **kwargs):
+        from services.qazlake_shadow_feed import local_collection_allowed
+
+        if not local_collection_allowed(family):
+            logger.info(
+                "Public schedule not registered after QazPipe cutover: %s",
+                kwargs.get("id", family),
+            )
+            return None
+        return _scheduler.add_job(func, trigger, **kwargs)
+
     # Fast tier — every 60 seconds
     _scheduler.add_job(
         lambda: _run_task_with_health(update_fast_data, "update_fast_data"),
@@ -827,8 +907,11 @@ def start_scheduler():
         except Exception as exc:
             logger.error("GT analytics refresh after telegram failed: %s", exc)
 
-    _scheduler.add_job(
-        lambda: _run_task_with_health(_fetch_telegram_osint_with_gt, "fetch_telegram_osint"),
+    _add_public_job(
+        "events_media",
+        lambda: _run_task_with_health(
+            _fetch_telegram_osint_with_gt, "fetch_telegram_osint"
+        ),
         "interval",
         minutes=_telegram_interval_m,
         next_run_time=datetime.utcnow() + timedelta(seconds=45),
@@ -859,7 +942,8 @@ def start_scheduler():
     )
 
     # Weather alerts — every 5 minutes (time-critical, separate from slow tier)
-    _scheduler.add_job(
+    _add_public_job(
+        "weather_environment",
         lambda: _run_task_with_health(fetch_weather_alerts, "fetch_weather_alerts"),
         "interval",
         minutes=5,
@@ -928,7 +1012,8 @@ def start_scheduler():
     # added within the window simply fall back to UNKNOWN until refresh.
     from services.fetchers.route_database import refresh_route_database
 
-    _scheduler.add_job(
+    _add_public_job(
+        "aviation_public",
         lambda: _run_task_with_health(refresh_route_database, "refresh_route_database"),
         "interval",
         days=5,
@@ -944,8 +1029,11 @@ def start_scheduler():
     # newer drops without hammering the bucket.
     from services.fetchers.aircraft_database import refresh_aircraft_database
 
-    _scheduler.add_job(
-        lambda: _run_task_with_health(refresh_aircraft_database, "refresh_aircraft_database"),
+    _add_public_job(
+        "aviation_public",
+        lambda: _run_task_with_health(
+            refresh_aircraft_database, "refresh_aircraft_database"
+        ),
         "interval",
         days=5,
         id="aircraft_database",
@@ -963,8 +1051,11 @@ def start_scheduler():
         except Exception as exc:
             logger.error("GT analytics refresh after gdelt failed: %s", exc)
 
-    _scheduler.add_job(
-        lambda: _run_task_with_health_on_executor(_SLOW_EXECUTOR, _fetch_gdelt_with_gt, "fetch_gdelt"),
+    _add_public_job(
+        "events_media",
+        lambda: _run_task_with_health_on_executor(
+            _SLOW_EXECUTOR, _fetch_gdelt_with_gt, "fetch_gdelt"
+        ),
         "interval",
         minutes=30,
         id="gdelt",
@@ -1048,7 +1139,8 @@ def start_scheduler():
         except Exception as e:
             logger.warning(f"CCTV post-ingest refresh failed: {e}")
 
-    _scheduler.add_job(
+    _add_public_job(
+        "visual_reference",
         lambda: _run_task_with_health_on_executor(
             _SLOW_EXECUTOR, _run_cctv_ingest_cycle, "cctv_ingest_cycle"
         ),
@@ -1144,7 +1236,8 @@ def start_scheduler():
     # UAP sightings (NUFORC) — weekly Mondays 12:00 UTC. Rolling ~60-day window;
     # each self-hosted install pulls live nuforc.org so operators see current
     # reports (typically ~400–500 mappable pins). Disk cache TTL defaults to 7d.
-    _scheduler.add_job(
+    _add_public_job(
+        "uap_public",
         lambda: _run_task_with_health(
             lambda: fetch_uap_sightings(force_refresh=True),
             "fetch_uap_sightings",
@@ -1182,7 +1275,8 @@ def start_scheduler():
 
     # SAR catalog (Mode A) — every hour, free metadata from ASF Search.
     # No account, no downloads, no DSP.  Pure scene catalog + coverage hints.
-    _scheduler.add_job(
+    _add_public_job(
+        "visual_reference",
         lambda: _run_task_with_health(fetch_sar_catalog, "fetch_sar_catalog"),
         "interval",
         hours=1,

--- a/backend/services/mesh/mesh_crypto.py
+++ b/backend/services/mesh/mesh_crypto.py
@@ -178,6 +178,37 @@ def resolve_peer_key_for_url(peer_url: str) -> bytes:
     return _derive_peer_key(global_secret, normalized_url)
 
 
+def resolve_peer_key_candidates_for_url(peer_url: str) -> tuple[bytes, ...]:
+    """Return inbound verification keys for a bounded global-secret rotation.
+
+    The primary key is always first and remains the only outbound signing key.
+    A configured per-peer secret stays exclusive: the global previous secret is
+    never allowed to weaken per-peer identity.
+    """
+    normalized_url = normalize_peer_url(peer_url)
+    if not normalized_url:
+        return ()
+
+    primary_key = resolve_peer_key_for_url(normalized_url)
+    if not primary_key:
+        return ()
+    if _lookup_per_peer_secret(normalized_url):
+        return (primary_key,)
+
+    try:
+        from services.config import get_settings
+
+        previous_value = getattr(get_settings(), "MESH_PEER_PUSH_SECRET_PREVIOUS", "")
+        previous_secret = previous_value.strip() if isinstance(previous_value, str) else ""
+    except Exception:
+        previous_secret = ""
+
+    previous_key = _derive_peer_key(previous_secret, normalized_url)
+    if not previous_key or previous_key == primary_key:
+        return (primary_key,)
+    return (primary_key, previous_key)
+
+
 def _node_digest(public_key_b64: str) -> str:
     raw = base64.b64decode(public_key_b64)
     return hashlib.sha256(raw).hexdigest()

--- a/backend/services/mesh/mesh_fleet_defaults.py
+++ b/backend/services/mesh/mesh_fleet_defaults.py
@@ -16,10 +16,6 @@ FLEET_SEED_ONION_URLS = (
 FLEET_BOOTSTRAP_SIGNER_PUBLIC_KEY_B64 = (
     "ul1d0kj/ODPIp0OhHzX8eLAVXzJ3CVvzW1vn2IC6q3I="
 )
-# Shared fleet HMAC for sb-testnet peer announce/push/sync. Public testnet join model.
-FLEET_PEER_PUSH_SECRET = "b7GoqsvoUD9MV7tyt0ZOzMptLA84QG6KCfaV9nDqz5Y"
-
-
 def infonet_fleet_join_enabled() -> bool:
     try:
         from services.config import get_settings
@@ -54,8 +50,6 @@ def effective_peer_push_secret() -> str:
             return configured
     except Exception:
         pass
-    if infonet_fleet_join_enabled():
-        return FLEET_PEER_PUSH_SECRET
     return ""
 
 

--- a/backend/services/qazlake_shadow_feed.py
+++ b/backend/services/qazlake_shadow_feed.py
@@ -1,0 +1,898 @@
+"""Protected QazLake snapshot/events consumer for Shadow public projections."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+SCHEMA_VERSION = "qazlake.shadow-observations-feed/v1"
+VALID_MODES = frozenset({"local", "compare", "qazpipe"})
+FORBIDDEN_PUBLIC_PROPERTY_KEYS = frozenset(
+    {
+        "provider_id",
+        "source_id",
+        "collection_receipt_id",
+        "payload_hash_sha256",
+        "raw_payload",
+        "raw_provider_id",
+        "source_url",
+        "download_url",
+        "url",
+        "s3Urls",
+        "topology",
+        "credentials",
+    }
+)
+DEFAULT_FAMILY_LAYER_KEYS: dict[str, tuple[str, ...]] = {
+    "aviation_public": ("commercial_flights", "military_flights"),
+    "orbital_public": (
+        "satellites",
+        "satnogs_stations",
+        "satnogs_observations",
+        "tinygs_satellites",
+    ),
+    "geohazards": ("earthquakes", "volcanoes"),
+    "weather_environment": ("space_weather", "weather_alerts", "air_quality"),
+    "uap_public": ("uap_sightings",),
+    "network_observability": ("internet_outages",),
+    "events_media": ("gdelt", "news", "telegram_osint"),
+    "radio_public": ("kiwisdr", "psk_reporter"),
+    "visual_reference": ("cctv", "sar_scenes"),
+    "cyber_public": ("cyber_threats",),
+    "risk_reference_public": ("sanctions",),
+}
+LAYER_ENABLE_KEYS: dict[str, str] = {
+    "commercial_flights": "flights",
+    "military_flights": "military",
+    "gdelt": "global_incidents",
+    "satnogs_stations": "satnogs",
+    "satnogs_observations": "satnogs",
+}
+_lock = threading.RLock()
+_receipt_lock = threading.Lock()
+_stop = threading.Event()
+_thread: threading.Thread | None = None
+_state: dict[str, Any] = {
+    "entities": {},
+    "cursor": 0,
+    "watermark": None,
+    "refreshed_at": None,
+    "stale": True,
+    "error": "not_started",
+}
+
+
+def configured_modes() -> dict[str, str]:
+    raw = str(os.environ.get("SHADOW_LAYER_SOURCE_MODES", "") or "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        logger.error("SHADOW_LAYER_SOURCE_MODES must be a JSON object")
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(family): str(mode).lower()
+        for family, mode in parsed.items()
+        if str(mode).lower() in VALID_MODES and str(mode).lower() != "local"
+    }
+
+
+def uses_qazpipe_mode() -> bool:
+    return "qazpipe" in configured_modes().values()
+
+
+def _cache_path() -> Path:
+    return Path(
+        os.environ.get("SHADOW_QAZLAKE_CACHE_PATH", "data/qazlake_shadow_cache.json")
+    )
+
+
+def _receipt_path() -> Path:
+    return Path(
+        os.environ.get(
+            "SHADOW_QAZPIPE_COMPARE_RECEIPT_PATH",
+            "data/qazpipe_compare_receipts.jsonl",
+        )
+    )
+
+
+def _request_page(projection: str, cursor: int) -> dict[str, Any]:
+    base_url = str(os.environ.get("QAZLAKE_SHADOW_FEED_URL", "") or "").rstrip("/")
+    token = str(os.environ.get("QAZLAKE_SHADOW_FEED_TOKEN", "") or "").strip()
+    if not base_url or not token:
+        raise RuntimeError("QazLake Shadow feed URL/token are not configured")
+    query = urlencode({"cursor": max(0, int(cursor)), "limit": 1000})
+    request = Request(
+        f"{base_url}/api/internal/v1/feeds/shadow/{projection}?{query}",
+        headers={"X-QazLake-Shadow-Feed-Token": token, "Accept": "application/json"},
+        method="GET",
+    )
+    with urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read())
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unexpected QazLake Shadow feed contract")
+    if not isinstance(payload.get("items"), list):
+        raise TypeError("QazLake Shadow feed is missing items")
+    return payload
+
+
+def _save_cache() -> None:
+    path = _cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _lock:
+        serializable = dict(_state)
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(
+        json.dumps(
+            serializable, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ),
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _load_cache() -> None:
+    path = _cache_path()
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return
+    if not isinstance(loaded, dict) or not isinstance(loaded.get("entities"), dict):
+        return
+    with _lock:
+        _state.update(loaded)
+        _state["stale"] = True
+        _state["error"] = "startup_cache"
+
+
+def _accept_items(items: list[Any], entities: dict[str, dict[str, Any]]) -> None:
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        entity_id = str(item.get("entity_id") or "").strip()
+        properties = item.get("properties")
+        if not entity_id or not isinstance(properties, dict):
+            continue
+        entities[entity_id] = item
+
+
+def refresh_snapshot() -> None:
+    cursor = 0
+    entities: dict[str, dict[str, Any]] = {}
+    watermark = None
+    while True:
+        page = _request_page("snapshot", cursor)
+        _accept_items(page["items"], entities)
+        watermark = page.get("watermark")
+        next_cursor = page.get("next_cursor")
+        if not page.get("has_more") or next_cursor is None:
+            cursor = int((watermark or {}).get("cursor") or cursor)
+            break
+        cursor = int(next_cursor)
+    with _lock:
+        _state.update(
+            {
+                "entities": entities,
+                "cursor": cursor,
+                "watermark": watermark,
+                "refreshed_at": datetime.now(UTC).isoformat(),
+                "stale": False,
+                "error": None,
+            }
+        )
+    _save_cache()
+
+
+def poll_events() -> None:
+    with _lock:
+        cursor = int(_state.get("cursor") or 0)
+        entities = dict(_state.get("entities") or {})
+    watermark = None
+    while True:
+        page = _request_page("events", cursor)
+        _accept_items(page["items"], entities)
+        watermark = page.get("watermark")
+        next_cursor = page.get("next_cursor")
+        if next_cursor is not None:
+            cursor = int(next_cursor)
+        if not page.get("has_more"):
+            break
+    with _lock:
+        _state.update(
+            {
+                "entities": entities,
+                "cursor": cursor,
+                "watermark": watermark or _state.get("watermark"),
+                "refreshed_at": datetime.now(UTC).isoformat(),
+                "stale": False,
+                "error": None,
+            }
+        )
+    _save_cache()
+
+
+def _mark_stale(exc: Exception) -> None:
+    with _lock:
+        _state["stale"] = True
+        _state["error"] = type(exc).__name__
+    logger.warning(
+        "QazLake Shadow feed refresh failed; retaining last valid snapshot: %s",
+        type(exc).__name__,
+    )
+
+
+def _sync_loop() -> None:
+    try:
+        refresh_snapshot()
+    except (HTTPError, URLError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        _mark_stale(exc)
+    interval = max(
+        10, int(os.environ.get("QAZLAKE_SHADOW_POLL_INTERVAL_S", "30") or 30)
+    )
+    while not _stop.wait(interval):
+        try:
+            poll_events()
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            _mark_stale(exc)
+
+
+def start_shadow_feed_sync() -> None:
+    global _thread
+    if not configured_modes():
+        return
+    _load_cache()
+    if _thread and _thread.is_alive():
+        return
+    _stop.clear()
+    _thread = threading.Thread(
+        target=_sync_loop, daemon=True, name="qazlake-shadow-feed"
+    )
+    _thread.start()
+
+
+def stop_shadow_feed_sync() -> None:
+    _stop.set()
+
+
+def _public_item(item: dict[str, Any]) -> dict[str, Any]:
+    properties = {
+        key: value
+        for key, value in dict(item.get("properties") or {}).items()
+        if key not in FORBIDDEN_PUBLIC_PROPERTY_KEYS
+    }
+    entity_id = str(item.get("entity_id") or "")
+    result = {"id": entity_id, "entity_id": entity_id, **properties}
+    if item.get("latitude") is not None:
+        result["latitude"] = item["latitude"]
+        result["lat"] = item["latitude"]
+    if item.get("longitude") is not None:
+        result["longitude"] = item["longitude"]
+        result["lng"] = item["longitude"]
+    if isinstance(item.get("geometry"), dict):
+        result["geometry"] = item["geometry"]
+    result["observed_at"] = item.get("observed_at")
+    layer_key = str(properties.get("layer_key") or "")
+    if layer_key in {"commercial_flights", "military_flights"}:
+        external_id = str(
+            item.get("external_id") or entity_id.removeprefix("aircraft:")
+        ).lower()
+        altitude_m = properties.get("altitude_m")
+        speed_mps = properties.get("speed_mps")
+        model = str(properties.get("aircraft_model") or "").strip().upper()
+        category = str(properties.get("aircraft_category") or "").strip().upper()
+        result.update(
+            {
+                "id": external_id or entity_id,
+                "icao24": external_id,
+                "callsign": properties.get("callsign")
+                or external_id.upper()
+                or "UNKNOWN",
+                "alt": (
+                    round(float(altitude_m) / 0.3048)
+                    if isinstance(altitude_m, (int, float))
+                    else None
+                ),
+                "heading": properties.get("heading_deg") or 0,
+                "speed_knots": (
+                    round(float(speed_mps) / 0.514444, 1)
+                    if isinstance(speed_mps, (int, float))
+                    else None
+                ),
+                "registration": properties.get("registration") or "N/A",
+                "model": model or "Unknown",
+                "squawk": properties.get("squawk") or None,
+                "aircraft_category": "heli" if category == "A7" else "plane",
+                # QazLake stays provider-neutral; the product projection carries
+                # the attribution required when ADSB.lol data is shown publicly.
+                "source": "ADSB.lol contributors",
+            }
+        )
+        if layer_key == "military_flights":
+            from services.fetchers.military import (
+                _classify_military_type,
+                _enrich_country,
+            )
+
+            country, force = _enrich_country(external_id, "")
+            result.update(
+                {
+                    "type": "military_flight",
+                    "country": country,
+                    "force": force,
+                    "military_type": _classify_military_type(model),
+                    "origin_loc": None,
+                    "dest_loc": None,
+                    "origin_name": "UNKNOWN",
+                    "dest_name": "UNKNOWN",
+                }
+            )
+        else:
+            result.update(
+                {
+                    "type": "commercial_flight",
+                    "country": "N/A",
+                    "origin_loc": None,
+                    "dest_loc": None,
+                    "origin_name": "UNKNOWN",
+                    "dest_name": "UNKNOWN",
+                }
+            )
+    elif layer_key == "earthquakes":
+        if properties.get("magnitude") is not None:
+            result["mag"] = properties["magnitude"]
+        if properties.get("place") is not None:
+            result["place"] = properties["place"]
+    elif layer_key == "air_quality":
+        if properties.get("pm25_ug_m3") is not None:
+            result["pm25"] = properties["pm25_ug_m3"]
+        if properties.get("aqi_us_epa") is not None:
+            result["aqi"] = properties["aqi_us_epa"]
+        if properties.get("name") is not None:
+            result["name"] = properties["name"]
+        if properties.get("country_code") is not None:
+            result["country"] = properties["country_code"]
+    elif layer_key == "space_weather":
+        if properties.get("kp_index") is not None:
+            result["kp_index"] = properties["kp_index"]
+        category = str(properties.get("category") or "").lower()
+        if category.startswith("g"):
+            result["kp_text"] = f"STORM {category.split('_', 1)[0].upper()}"
+        elif category == "active":
+            result["kp_text"] = "ACTIVE"
+        elif properties.get("kp_index") is not None and properties["kp_index"] >= 3:
+            result["kp_text"] = "UNSETTLED"
+        else:
+            result["kp_text"] = "QUIET"
+        result["events"] = []
+    elif layer_key == "sanctions":
+        external_id = str(
+            item.get("external_id") or entity_id.removeprefix("sanctions:ofac-sdn:")
+        ).strip()
+        listing_type = str(properties.get("listing_type") or "Entity").strip()
+        schema = {
+            "Individual": "Person",
+            "Entity": "LegalEntity",
+            "Vessel": "Vessel",
+            "Aircraft": "Airplane",
+        }.get(listing_type, listing_type or "LegalEntity")
+        aliases = [str(value) for value in properties.get("aliases") or []]
+        countries = [str(value) for value in properties.get("countries") or []]
+        programs = [str(value) for value in properties.get("programs") or []]
+        observed_at = item.get("observed_at")
+        result.update(
+            {
+                "id": external_id or entity_id,
+                "schema": schema,
+                "name": str(properties.get("name") or "").strip(),
+                "aliases": aliases,
+                "countries": countries,
+                "programs": programs,
+                "sanctions": "; ".join(programs),
+                "first_seen": observed_at,
+                "last_seen": observed_at,
+            }
+        )
+    elif layer_key == "satnogs_stations":
+        if properties.get("altitude_m") is not None:
+            result["altitude"] = properties["altitude_m"]
+        if properties.get("observation_count") is not None:
+            result["observations"] = properties["observation_count"]
+        if properties.get("last_seen_at") is not None:
+            result["last_seen"] = properties["last_seen_at"]
+    elif layer_key == "satnogs_observations":
+        if properties.get("norad_catalog_id") is not None:
+            result["norad_id"] = properties["norad_catalog_id"]
+        if properties.get("started_at") is not None:
+            result["start"] = properties["started_at"]
+        if properties.get("ended_at") is not None:
+            result["end"] = properties["ended_at"]
+        if properties.get("frequency_hz") is not None:
+            result["frequency"] = properties["frequency_hz"]
+    elif layer_key == "cyber_threats":
+        if properties.get("cve_id") is not None:
+            result["id"] = properties["cve_id"]
+        if properties.get("date_added") is not None:
+            result["date"] = properties["date_added"]
+        if properties.get("due_date") is not None:
+            result["due"] = properties["due_date"]
+    elif layer_key == "weather_alerts":
+        if properties.get("alert_id") is not None:
+            result["id"] = properties["alert_id"]
+        if properties.get("expires_at") is not None:
+            result["expires"] = properties["expires_at"]
+    elif layer_key == "sar_scenes":
+        scene_id = str(item.get("external_id") or entity_id.removeprefix("sar_scene:"))
+        result["scene_id"] = scene_id
+        result["mode"] = properties.get("beam_mode") or ""
+        result["level"] = properties.get("processing_level") or ""
+        result["time"] = properties.get("acquisition_start_at") or item.get(
+            "observed_at"
+        )
+        result["bbox"] = _geometry_bbox(item.get("geometry")) or []
+        # Keep the legacy public shape without reintroducing product downloads
+        # or provider-specific identifiers into the QazLake projection.
+        result["download_url"] = ""
+        result["provider"] = "QazLake"
+    return result
+
+
+def _geometry_bbox(value: object) -> list[float] | None:
+    if not isinstance(value, dict) or not isinstance(value.get("coordinates"), list):
+        return None
+    points: list[tuple[float, float]] = []
+
+    def visit(coordinates: object) -> None:
+        if not isinstance(coordinates, list):
+            return
+        if len(coordinates) >= 2 and all(
+            isinstance(coordinates[index], (int, float))
+            and not isinstance(coordinates[index], bool)
+            for index in (0, 1)
+        ):
+            longitude = float(coordinates[0])
+            latitude = float(coordinates[1])
+            if (
+                math.isfinite(longitude)
+                and math.isfinite(latitude)
+                and -180 <= longitude <= 180
+                and -90 <= latitude <= 90
+            ):
+                points.append((longitude, latitude))
+            return
+        for child in coordinates:
+            visit(child)
+
+    visit(value["coordinates"])
+    if not points:
+        return None
+    longitudes = [point[0] for point in points]
+    latitudes = [point[1] for point in points]
+    return [min(longitudes), min(latitudes), max(longitudes), max(latitudes)]
+
+
+def _latest_item(items: list[dict[str, Any]]) -> dict[str, Any] | None:
+    def observed_at(item: dict[str, Any]) -> datetime:
+        raw = str(item.get("observed_at") or "").replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return datetime.min.replace(tzinfo=UTC)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+
+    return max(items, key=observed_at) if items else None
+
+
+def _public_layer_value(layer_key: str, items: list[dict[str, Any]]) -> Any:
+    """Keep public singleton layers shape-compatible after QazLake cutover."""
+    if layer_key == "space_weather":
+        return _latest_item(items) or {
+            "kp_index": None,
+            "kp_text": "QUIET",
+            "events": [],
+        }
+    if layer_key == "telegram_osint":
+        return {
+            "posts": items,
+            "total": len(items),
+            "geolocated": sum(
+                1
+                for item in items
+                if item.get("lat") is not None and item.get("lng") is not None
+            ),
+        }
+    if layer_key == "cyber_threats":
+        cutoff = datetime.now(UTC) - timedelta(days=30)
+        recent: list[dict[str, Any]] = []
+        for item in items:
+            raw_date = item.get("date_added") or item.get("date")
+            try:
+                added = datetime.fromisoformat(str(raw_date)).replace(tzinfo=UTC)
+            except (TypeError, ValueError):
+                continue
+            if added >= cutoff:
+                recent.append(item)
+        recent.sort(
+            key=lambda item: (
+                str(item.get("date_added") or ""),
+                str(item.get("id") or ""),
+            ),
+            reverse=True,
+        )
+        recent = recent[:10]
+        threats = [
+            {
+                "id": item.get("cve_id") or item.get("id"),
+                "name": item.get("name"),
+                "vendor": item.get("vendor"),
+                "product": item.get("product"),
+                "severity": "CRITICAL",
+                "date": item.get("date_added") or item.get("date"),
+                "due": item.get("due_date") or item.get("due"),
+                "source": "CISA KEV",
+            }
+            for item in recent
+        ]
+        catalog_counts = [
+            item.get("catalog_count")
+            for item in items
+            if isinstance(item.get("catalog_count"), int)
+        ]
+        release_dates = [
+            str(item.get("catalog_released_at"))
+            for item in items
+            if item.get("catalog_released_at")
+        ]
+        active_count = len(threats)
+        return {
+            "threats": threats,
+            "stats": {
+                "cisa_total": max(catalog_counts, default=len(items)),
+                "active_cves": active_count,
+                "threat_level": (
+                    "CRITICAL"
+                    if active_count >= 8
+                    else "HIGH"
+                    if active_count >= 4
+                    else "ELEVATED"
+                ),
+            },
+            "timestamp": max(release_dates, default=None),
+        }
+    if layer_key == "weather_alerts":
+        now = datetime.now(UTC)
+        active: list[dict[str, Any]] = []
+        for item in items:
+            raw_expiry = item.get("expires_at") or item.get("expires")
+            try:
+                expiry = datetime.fromisoformat(str(raw_expiry).replace("Z", "+00:00"))
+            except (TypeError, ValueError):
+                continue
+            if expiry.tzinfo is None:
+                expiry = expiry.replace(tzinfo=UTC)
+            if expiry.astimezone(UTC) > now:
+                active.append(item)
+        active.sort(
+            key=lambda item: (str(item.get("expires") or ""), str(item.get("id") or ""))
+        )
+        return active
+    return items
+
+
+def _items_by_family() -> dict[str, dict[str, list[dict[str, Any]]]]:
+    grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    with _lock:
+        entities = list((_state.get("entities") or {}).values())
+    for item in entities:
+        properties = item.get("properties") if isinstance(item, dict) else None
+        family = str((properties or {}).get("layer_family") or "").strip()
+        layer_key = str((properties or {}).get("layer_key") or family).strip()
+        if family:
+            grouped.setdefault(family, {}).setdefault(layer_key, []).append(
+                _public_item(item)
+            )
+    return grouped
+
+
+def _family_layer_keys(family: str) -> tuple[str, ...]:
+    configured = _json_mapping("SHADOW_LAYER_FAMILY_KEYS")
+    value = configured.get(family)
+    if isinstance(value, list):
+        keys = tuple(str(key).strip() for key in value if str(key).strip())
+        if keys:
+            return keys
+    return DEFAULT_FAMILY_LAYER_KEYS.get(family, (family,))
+
+
+def _canonical_ids(items: Any) -> set[str]:
+    if not isinstance(items, list):
+        return set()
+    ids = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        identity = next(
+            (
+                item.get(key)
+                for key in ("entity_id", "id", "hex", "icao24", "mmsi")
+                if item.get(key)
+            ),
+            None,
+        )
+        if identity is not None:
+            ids.add(str(identity))
+    return ids
+
+
+def _comparison_rows(layer_key: str, value: Any) -> list[dict[str, Any]]:
+    """Normalize public singleton and collection shapes for comparison only."""
+    if layer_key == "space_weather":
+        item = _latest_item(value) if isinstance(value, list) else value
+        if not isinstance(item, dict):
+            return []
+        normalized = dict(item)
+        # The legacy singleton has no public ID. Its layer identity is stable
+        # and must compare with the QazLake current-entity projection.
+        normalized["id"] = layer_key
+        return [normalized]
+    if layer_key == "cyber_threats":
+        projected = (
+            _public_layer_value(layer_key, value) if isinstance(value, list) else value
+        )
+        if not isinstance(projected, dict) or not isinstance(
+            projected.get("threats"), list
+        ):
+            return []
+        return [item for item in projected["threats"] if isinstance(item, dict)]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _json_mapping(name: str) -> dict[str, Any]:
+    raw = str(os.environ.get(name, "") or "").strip()
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        logger.error("%s must be a JSON object", name)
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _latest_observed_at(items: Any) -> datetime | None:
+    latest: datetime | None = None
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, dict):
+            continue
+        raw = item.get("observed_at") or item.get("timestamp") or item.get("updated_at")
+        if not raw:
+            continue
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            parsed = parsed.astimezone(UTC)
+        except (TypeError, ValueError):
+            continue
+        latest = parsed if latest is None or parsed > latest else latest
+    return latest
+
+
+def _required_null_rate(items: Any, required_fields: list[str]) -> float:
+    rows = (
+        [item for item in items if isinstance(item, dict)]
+        if isinstance(items, list)
+        else []
+    )
+    if not rows or not required_fields:
+        return 0.0
+    missing = sum(
+        1 for item in rows for field in required_fields if item.get(field) is None
+    )
+    return missing / (len(rows) * len(required_fields))
+
+
+def _write_compare_receipt(
+    endpoint: str,
+    family: str,
+    layer_key: str,
+    local: Any,
+    candidate: Any,
+) -> None:
+    local_rows = _comparison_rows(layer_key, local)
+    candidate_rows = _comparison_rows(layer_key, candidate)
+    local_ids = _canonical_ids(local_rows)
+    candidate_ids = _canonical_ids(candidate_rows)
+    union = local_ids | candidate_ids
+    overlap = len(local_ids & candidate_ids) / len(union) if union else 1.0
+    comparison_kinds = _json_mapping("SHADOW_COMPARE_FAMILY_KINDS")
+    comparison_kind = str(comparison_kinds.get(family) or "streaming").lower()
+    if comparison_kind not in {"deterministic", "streaming"}:
+        comparison_kind = "streaming"
+    required_config = _json_mapping("SHADOW_COMPARE_REQUIRED_FIELDS")
+    required_fields = [
+        str(field)
+        for field in required_config.get(family, [])
+        if isinstance(field, str) and field
+    ]
+    local_null_rate = _required_null_rate(local_rows, required_fields)
+    candidate_null_rate = _required_null_rate(candidate_rows, required_fields)
+    null_rate_delta = candidate_null_rate - local_null_rate
+    cadence_config = _json_mapping("SHADOW_COMPARE_CADENCE_SECONDS")
+    try:
+        cadence_seconds = max(0, int(cadence_config.get(family, 0)))
+    except (TypeError, ValueError):
+        cadence_seconds = 0
+    local_latest = _latest_observed_at(local_rows)
+    candidate_latest = _latest_observed_at(candidate_rows)
+    freshness_lag_seconds = None
+    freshness_ok = True
+    if local_latest is not None:
+        freshness_lag_seconds = (
+            (local_latest - candidate_latest).total_seconds()
+            if candidate_latest is not None
+            else None
+        )
+        freshness_ok = (
+            candidate_latest is not None and freshness_lag_seconds <= cadence_seconds
+        )
+    deterministic_ok = local_ids == candidate_ids and len(local_rows) == len(
+        candidate_rows
+    )
+    identity_ok = (
+        deterministic_ok if comparison_kind == "deterministic" else overlap >= 0.90
+    )
+    status = shadow_feed_status()
+    watermark = status["watermark"]
+    watermark_ok = (
+        isinstance(watermark, dict)
+        and isinstance(watermark.get("cursor"), int)
+        and watermark["cursor"] >= 0
+    )
+    accepted = (
+        identity_ok
+        and freshness_ok
+        and null_rate_delta <= 0.01
+        and watermark_ok
+        and not status["stale"]
+    )
+    receipt = {
+        "schema_version": "shadow.qazpipe-comparison-receipt/v1",
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "endpoint": endpoint,
+        "layer_family": family,
+        "layer_key": layer_key,
+        "comparison_kind": comparison_kind,
+        "local_count": len(local_rows),
+        "qazlake_count": len(candidate_rows),
+        "id_overlap": overlap,
+        "canonical_ids_exact": local_ids == candidate_ids,
+        "required_fields": required_fields,
+        "local_required_null_rate": local_null_rate,
+        "qazlake_required_null_rate": candidate_null_rate,
+        "required_null_rate_delta": null_rate_delta,
+        "freshness_lag_seconds": freshness_lag_seconds,
+        "cadence_seconds": cadence_seconds,
+        "watermark": watermark,
+        "watermark_valid": watermark_ok,
+        "stale": status["stale"],
+        "accepted": accepted,
+        "failed_gates": [
+            name
+            for name, passed in (
+                ("canonical_identity", identity_ok),
+                ("freshness", freshness_ok),
+                ("required_null_rate", null_rate_delta <= 0.01),
+                ("watermark", watermark_ok),
+                ("feed_current", not status["stale"]),
+            )
+            if not passed
+        ],
+    }
+    path = _receipt_path()
+    try:
+        with _receipt_lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(receipt, ensure_ascii=False, sort_keys=True) + "\n"
+                )
+    except OSError as exc:
+        logger.error(
+            "Unable to write QazLake comparison receipt: %s", type(exc).__name__
+        )
+
+
+def shadow_feed_status() -> dict[str, Any]:
+    with _lock:
+        return {
+            "stale": bool(_state.get("stale", True)),
+            "available": bool(_state.get("entities")),
+            "watermark": _state.get("watermark"),
+            "refreshed_at": _state.get("refreshed_at"),
+            "error": _state.get("error"),
+        }
+
+
+def shadow_feed_etag_suffix() -> str:
+    modes = configured_modes()
+    if not modes:
+        return ""
+    status = shadow_feed_status()
+    material = json.dumps(
+        {"modes": modes, "watermark": status["watermark"], "stale": status["stale"]},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return "qazlake-" + hashlib.sha256(material).hexdigest()[:12] + "|"
+
+
+def apply_layer_source_modes(
+    payload: dict[str, Any],
+    *,
+    endpoint: str,
+    enabled_layers: dict[str, bool] | None = None,
+) -> dict[str, Any]:
+    modes = configured_modes()
+    if not modes:
+        return payload
+    grouped = _items_by_family()
+    for family, mode in modes.items():
+        for layer_key in _family_layer_keys(family):
+            if layer_key not in payload:
+                continue
+            enable_key = LAYER_ENABLE_KEYS.get(layer_key, layer_key)
+            if enabled_layers is not None and not enabled_layers.get(enable_key, True):
+                continue
+            candidate = grouped.get(family, {}).get(layer_key, [])
+            if mode == "compare":
+                _write_compare_receipt(
+                    endpoint,
+                    family,
+                    layer_key,
+                    payload.get(layer_key),
+                    candidate,
+                )
+            elif mode == "qazpipe":
+                # Fail visibly: an unavailable feed projects an empty layer and
+                # explicit stale state; it never falls back to the local collector.
+                payload[layer_key] = _public_layer_value(layer_key, candidate)
+    if "qazpipe" in modes.values():
+        status = shadow_feed_status()
+        payload["qazpipe_state"] = {
+            "schema_version": SCHEMA_VERSION,
+            "modes": modes,
+            "status": "stale" if status["stale"] else "current",
+            "available": status["available"],
+            "watermark": status["watermark"],
+            "refreshed_at": status["refreshed_at"],
+        }
+    return payload

--- a/backend/services/qazlake_shadow_feed.py
+++ b/backend/services/qazlake_shadow_feed.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,12 @@ DEFAULT_FAMILY_LAYER_KEYS: dict[str, tuple[str, ...]] = {
         "tinygs_satellites",
     ),
     "geohazards": ("earthquakes", "volcanoes"),
-    "weather_environment": ("space_weather", "weather_alerts", "air_quality"),
+    "weather_environment": (
+        "weather",
+        "space_weather",
+        "weather_alerts",
+        "air_quality",
+    ),
     "uap_public": ("uap_sightings",),
     "network_observability": ("internet_outages",),
     "events_media": ("gdelt", "news", "telegram_osint"),
@@ -55,6 +60,8 @@ DEFAULT_FAMILY_LAYER_KEYS: dict[str, tuple[str, ...]] = {
     "visual_reference": ("cctv", "sar_scenes"),
     "cyber_public": ("cyber_threats",),
     "risk_reference_public": ("sanctions",),
+    "transport_public": ("trains",),
+    "infrastructure_public": ("datacenters", "power_plants"),
 }
 LAYER_ENABLE_KEYS: dict[str, str] = {
     "commercial_flights": "flights",
@@ -91,12 +98,61 @@ def configured_modes() -> dict[str, str]:
     return {
         str(family): str(mode).lower()
         for family, mode in parsed.items()
-        if str(mode).lower() in VALID_MODES and str(mode).lower() != "local"
+        if str(family) in DEFAULT_FAMILY_LAYER_KEYS
+        and str(mode).lower() in VALID_MODES
+        and str(mode).lower() != "local"
     }
+
+
+def validate_shadow_feed_configuration() -> None:
+    """Fail closed on an explicit but unsafe or incomplete cutover config."""
+    raw = str(os.environ.get("SHADOW_LAYER_SOURCE_MODES", "") or "").strip()
+    if not raw:
+        return
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("SHADOW_LAYER_SOURCE_MODES must be a JSON object") from exc
+    if not isinstance(parsed, dict):
+        raise TypeError("SHADOW_LAYER_SOURCE_MODES must be a JSON object")
+    unknown_families = sorted(set(map(str, parsed)) - set(DEFAULT_FAMILY_LAYER_KEYS))
+    if unknown_families:
+        raise RuntimeError(
+            "unsupported Shadow source families: " + ", ".join(unknown_families)
+        )
+    invalid_modes = sorted(
+        f"{family}={mode}"
+        for family, mode in parsed.items()
+        if str(mode).lower() not in VALID_MODES
+    )
+    if invalid_modes:
+        raise RuntimeError("invalid Shadow source modes: " + ", ".join(invalid_modes))
+    if not any(str(mode).lower() != "local" for mode in parsed.values()):
+        return
+
+    base_url = str(os.environ.get("QAZLAKE_SHADOW_FEED_URL", "") or "").rstrip("/")
+    token = str(os.environ.get("QAZLAKE_SHADOW_FEED_TOKEN", "") or "").strip()
+    if not base_url or not token:
+        raise RuntimeError(
+            "QazLake Shadow feed URL/token are required for compare or qazpipe mode"
+        )
+    parsed_url = urlparse(base_url)
+    is_local_http = parsed_url.scheme == "http" and parsed_url.hostname in {
+        "127.0.0.1",
+        "localhost",
+        "testserver",
+    }
+    if parsed_url.scheme != "https" and not is_local_http:
+        raise RuntimeError("QazLake Shadow feed URL must use HTTPS")
 
 
 def uses_qazpipe_mode() -> bool:
     return "qazpipe" in configured_modes().values()
+
+
+def local_collection_allowed(family: str) -> bool:
+    """Keep local collection during compare; stop it only after family cutover."""
+    return configured_modes().get(str(family)) != "qazpipe"
 
 
 def _cache_path() -> Path:
@@ -276,7 +332,12 @@ def start_shadow_feed_sync() -> None:
 
 
 def stop_shadow_feed_sync() -> None:
+    global _thread
     _stop.set()
+    thread = _thread
+    if thread and thread.is_alive():
+        thread.join(timeout=5)
+    _thread = None
 
 
 def _public_item(item: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/mesh/test_mesh_fleet_defaults.py
+++ b/backend/tests/mesh/test_mesh_fleet_defaults.py
@@ -1,6 +1,5 @@
 from services.mesh.mesh_fleet_defaults import (
     FLEET_SEED_ONION_URL,
-    FLEET_PEER_PUSH_SECRET,
     configured_bootstrap_seed_peers_with_fleet_default,
     effective_bootstrap_signer_public_key_b64,
     effective_fleet_seed_peers,
@@ -19,7 +18,19 @@ def test_fleet_defaults_apply_when_join_enabled(monkeypatch):
     try:
         assert infonet_fleet_join_enabled() is True
         assert effective_bootstrap_signer_public_key_b64()
-        assert effective_peer_push_secret() == FLEET_PEER_PUSH_SECRET
+        assert effective_peer_push_secret() == ""
+    finally:
+        get_settings.cache_clear()
+
+
+def test_peer_push_secret_requires_explicit_protected_configuration(monkeypatch):
+    from services.config import get_settings
+
+    monkeypatch.setenv("MESH_PEER_PUSH_SECRET", "operator-managed-secret-value")
+    monkeypatch.setenv("MESH_INFONET_FLEET_JOIN", "true")
+    get_settings.cache_clear()
+    try:
+        assert effective_peer_push_secret() == "operator-managed-secret-value"
     finally:
         get_settings.cache_clear()
 

--- a/backend/tests/test_p0_security.py
+++ b/backend/tests/test_p0_security.py
@@ -149,16 +149,13 @@ class TestValidatePeerPushSecret:
         with patch("main.get_settings", return_value=mock_settings):
             return _validate_peer_push_secret
 
-    def test_known_default_auto_generates_replacement(self):
+    def test_known_default_is_rejected(self):
         from auth import _validate_peer_push_secret
 
         mock_settings = MagicMock()
         mock_settings.MESH_PEER_PUSH_SECRET = _KNOWN_COMPROMISED
 
-        with (
-            patch("auth.get_settings", return_value=mock_settings),
-            patch("auth._auto_generate_peer_push_secret", return_value="replacement-secret-value"),
-        ):
+        with patch("auth.get_settings", return_value=mock_settings), pytest.raises(SystemExit):
             _validate_peer_push_secret()
 
     def test_empty_secret_does_not_exit_without_peers(self):
@@ -173,7 +170,7 @@ class TestValidatePeerPushSecret:
         with patch("auth.get_settings", return_value=mock_settings):
             _validate_peer_push_secret()  # no exception = pass
 
-    def test_empty_secret_with_peers_auto_generates_replacement(self):
+    def test_empty_secret_with_peers_is_rejected(self):
         from auth import _validate_peer_push_secret
 
         mock_settings = MagicMock()
@@ -182,13 +179,10 @@ class TestValidatePeerPushSecret:
         mock_settings.MESH_RNS_PEERS = ""
         mock_settings.MESH_RNS_ENABLED = False
 
-        with (
-            patch("auth.get_settings", return_value=mock_settings),
-            patch("auth._auto_generate_peer_push_secret", return_value="replacement-secret-value"),
-        ):
+        with patch("auth.get_settings", return_value=mock_settings), pytest.raises(SystemExit):
             _validate_peer_push_secret()
 
-    def test_short_secret_with_peers_auto_generates_replacement(self):
+    def test_short_secret_with_peers_is_rejected(self):
         from auth import _validate_peer_push_secret
 
         mock_settings = MagicMock()
@@ -197,10 +191,7 @@ class TestValidatePeerPushSecret:
         mock_settings.MESH_RNS_PEERS = ""
         mock_settings.MESH_RNS_ENABLED = False
 
-        with (
-            patch("auth.get_settings", return_value=mock_settings),
-            patch("auth._auto_generate_peer_push_secret", return_value="replacement-secret-value"),
-        ):
+        with patch("auth.get_settings", return_value=mock_settings), pytest.raises(SystemExit):
             _validate_peer_push_secret()
 
     def test_valid_secret_passes(self):
@@ -214,6 +205,32 @@ class TestValidatePeerPushSecret:
 
         with patch("auth.get_settings", return_value=mock_settings):
             _validate_peer_push_secret()  # no exception = pass
+
+    def test_valid_rotation_previous_passes(self):
+        from auth import _validate_peer_push_secret
+
+        mock_settings = MagicMock()
+        mock_settings.MESH_PEER_PUSH_SECRET = "new-primary-secret-value-12345"
+        mock_settings.MESH_PEER_PUSH_SECRET_PREVIOUS = "old-previous-secret-value-67890"
+        mock_settings.MESH_RELAY_PEERS = "https://peer.example"
+        mock_settings.MESH_RNS_PEERS = ""
+        mock_settings.MESH_RNS_ENABLED = False
+
+        with patch("auth.get_settings", return_value=mock_settings):
+            _validate_peer_push_secret()
+
+    def test_rotation_previous_must_differ_from_primary(self):
+        from auth import _validate_peer_push_secret
+
+        mock_settings = MagicMock()
+        mock_settings.MESH_PEER_PUSH_SECRET = "same-strong-secret-value-12345"
+        mock_settings.MESH_PEER_PUSH_SECRET_PREVIOUS = "same-strong-secret-value-12345"
+        mock_settings.MESH_RELAY_PEERS = "https://peer.example"
+        mock_settings.MESH_RNS_PEERS = ""
+        mock_settings.MESH_RNS_ENABLED = False
+
+        with patch("auth.get_settings", return_value=mock_settings), pytest.raises(SystemExit):
+            _validate_peer_push_secret()
 
     def test_whitespace_only_treated_as_empty(self):
         from auth import _validate_peer_push_secret

--- a/backend/tests/test_per_peer_secret_resolver.py
+++ b/backend/tests/test_per_peer_secret_resolver.py
@@ -133,11 +133,12 @@ class TestResolvePeerKeyForUrl:
         mesh_crypto._PEER_SECRETS_CACHE = {}
         mesh_crypto._PEER_SECRETS_CACHE_RAW = ""
 
-    def _fake_settings(self, global_secret: str):
+    def _fake_settings(self, global_secret: str, previous_secret: str = ""):
         from unittest.mock import MagicMock
 
         s = MagicMock()
         s.MESH_PEER_PUSH_SECRET = global_secret
+        s.MESH_PEER_PUSH_SECRET_PREVIOUS = previous_secret
         return s
 
     def test_falls_back_to_global_when_no_per_peer_entry(self, monkeypatch):
@@ -230,6 +231,74 @@ class TestResolvePeerKeyForUrl:
             assert resolve_peer_key_for_url("") == b""
             assert resolve_peer_key_for_url("not-a-url") == b""
             assert resolve_peer_key_for_url(None) == b""
+
+    def test_rotation_candidates_accept_primary_then_previous(self, monkeypatch):
+        from services.mesh.mesh_crypto import (
+            _derive_peer_key,
+            resolve_peer_key_candidates_for_url,
+            resolve_peer_key_for_url,
+        )
+
+        peer_url = "https://peer.example"
+        monkeypatch.delenv("MESH_PEER_SECRETS", raising=False)
+        with monkeypatch.context() as m:
+            m.setattr(
+                "services.config.get_settings",
+                lambda: self._fake_settings("new-primary-secret", "old-previous-secret"),
+            )
+            assert resolve_peer_key_for_url(peer_url) == _derive_peer_key(
+                "new-primary-secret", peer_url
+            )
+            assert resolve_peer_key_candidates_for_url(peer_url) == (
+                _derive_peer_key("new-primary-secret", peer_url),
+                _derive_peer_key("old-previous-secret", peer_url),
+            )
+
+    def test_rotation_previous_is_not_allowed_for_per_peer_identity(self, monkeypatch):
+        from services.mesh.mesh_crypto import (
+            _derive_peer_key,
+            resolve_peer_key_candidates_for_url,
+        )
+
+        peer_url = "https://peer.example"
+        monkeypatch.setenv("MESH_PEER_SECRETS", f"{peer_url}=peer-specific-secret")
+        with monkeypatch.context() as m:
+            m.setattr(
+                "services.config.get_settings",
+                lambda: self._fake_settings("new-primary-secret", "old-previous-secret"),
+            )
+            assert resolve_peer_key_candidates_for_url(peer_url) == (
+                _derive_peer_key("peer-specific-secret", peer_url),
+            )
+
+    def test_previous_verifies_inbound_only_until_removed(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from auth import _verify_peer_transport_hmac
+        from services.mesh.mesh_crypto import _derive_peer_key
+
+        peer_url = "https://peer.example"
+        body = b'{"events":[]}'
+        previous_key = _derive_peer_key("old-previous-secret", peer_url)
+        signature = hmac.new(previous_key, body, hashlib.sha256).hexdigest()
+        request = SimpleNamespace(
+            headers={"x-peer-url": peer_url, "x-peer-hmac": signature},
+        )
+
+        monkeypatch.delenv("MESH_PEER_SECRETS", raising=False)
+        with monkeypatch.context() as m:
+            m.setattr(
+                "services.config.get_settings",
+                lambda: self._fake_settings("new-primary-secret", "old-previous-secret"),
+            )
+            assert _verify_peer_transport_hmac(request, body) is True
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "services.config.get_settings",
+                lambda: self._fake_settings("new-primary-secret", ""),
+            )
+            assert _verify_peer_transport_hmac(request, body) is False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_qazlake_shadow_feed_client.py
+++ b/backend/tests/test_qazlake_shadow_feed_client.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from services import qazlake_shadow_feed as feed
 
 
@@ -24,6 +26,53 @@ def test_invalid_or_local_modes_do_not_activate_client(monkeypatch) -> None:
     )
 
     assert feed.configured_modes() == {"weather_environment": "compare"}
+
+
+def test_explicit_cutover_configuration_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"geohazards": "qazpipe"})
+    )
+    monkeypatch.delenv("QAZLAKE_SHADOW_FEED_URL", raising=False)
+    monkeypatch.delenv("QAZLAKE_SHADOW_FEED_TOKEN", raising=False)
+
+    with pytest.raises(RuntimeError, match="URL/token"):
+        feed.validate_shadow_feed_configuration()
+
+
+def test_cutover_configuration_rejects_private_or_unknown_family(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"operator_private": "qazpipe"})
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported Shadow source families"):
+        feed.validate_shadow_feed_configuration()
+
+
+def test_cutover_configuration_requires_https_outside_localhost(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"geohazards": "compare"})
+    )
+    monkeypatch.setenv("QAZLAKE_SHADOW_FEED_URL", "http://qazlake.internal")
+    monkeypatch.setenv("QAZLAKE_SHADOW_FEED_TOKEN", "shadow-feed-token")
+
+    with pytest.raises(RuntimeError, match="HTTPS"):
+        feed.validate_shadow_feed_configuration()
+
+
+def test_local_collection_stops_only_after_family_cutover(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES",
+        json.dumps(
+            {
+                "geohazards": "compare",
+                "transport_public": "qazpipe",
+            }
+        ),
+    )
+
+    assert feed.local_collection_allowed("geohazards") is True
+    assert feed.local_collection_allowed("transport_public") is False
+    assert feed.local_collection_allowed("operator_private") is True
 
 
 def test_compare_preserves_public_payload_and_records_receipt(
@@ -75,6 +124,36 @@ def test_qazpipe_mode_never_hides_failure_with_local_fallback(monkeypatch) -> No
     assert result["earthquakes"] == []
     assert result["qazpipe_state"]["status"] == "stale"
     assert result["qazpipe_state"]["available"] is False
+
+
+def test_transport_cutover_preserves_legacy_layer_shape(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"transport_public": "qazpipe"})
+    )
+    monkeypatch.setattr(
+        feed,
+        "_items_by_family",
+        lambda: {
+            "transport_public": {
+                "trains": [{"id": "train:2026-08-28:1", "speed_mps": 30.0}]
+            }
+        },
+    )
+    with feed._lock:
+        feed._state.update(
+            {
+                "entities": {"train:2026-08-28:1": {}},
+                "stale": False,
+                "watermark": {"cursor": 42},
+            }
+        )
+
+    result = feed.apply_layer_source_modes(
+        {"trains": [{"id": "local-train"}]}, endpoint="fast"
+    )
+
+    assert result["trains"] == [{"id": "train:2026-08-28:1", "speed_mps": 30.0}]
+    assert result["qazpipe_state"]["status"] == "current"
 
 
 def test_projection_filters_storage_and_provider_fields() -> None:

--- a/backend/tests/test_qazlake_shadow_feed_client.py
+++ b/backend/tests/test_qazlake_shadow_feed_client.py
@@ -1,0 +1,112 @@
+import json
+
+from services import qazlake_shadow_feed as feed
+
+
+def test_client_is_dormant_without_explicit_modes(monkeypatch) -> None:
+    monkeypatch.delenv("SHADOW_LAYER_SOURCE_MODES", raising=False)
+    payload = {"earthquakes": [{"id": "local-1"}]}
+
+    assert feed.configured_modes() == {}
+    assert feed.apply_layer_source_modes(payload, endpoint="slow") is payload
+
+
+def test_invalid_or_local_modes_do_not_activate_client(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES",
+        json.dumps(
+            {
+                "geohazards": "local",
+                "aviation_public": "unexpected",
+                "weather_environment": "compare",
+            }
+        ),
+    )
+
+    assert feed.configured_modes() == {"weather_environment": "compare"}
+
+
+def test_compare_preserves_public_payload_and_records_receipt(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"geohazards": "compare"})
+    )
+    receipt_path = tmp_path / "receipts.jsonl"
+    monkeypatch.setenv("SHADOW_QAZPIPE_COMPARE_RECEIPT_PATH", str(receipt_path))
+    monkeypatch.setattr(
+        feed,
+        "_items_by_family",
+        lambda: {"geohazards": {"earthquakes": [{"id": "candidate-1"}]}},
+    )
+    with feed._lock:
+        feed._state.update(
+            {
+                "entities": {"candidate-1": {}},
+                "stale": False,
+                "watermark": {"cursor": 7},
+            }
+        )
+    local = [{"id": "local-1"}]
+    payload = {"earthquakes": local}
+
+    result = feed.apply_layer_source_modes(payload, endpoint="slow")
+
+    assert result == {"earthquakes": local}
+    assert result["earthquakes"] is local
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["schema_version"] == "shadow.qazpipe-comparison-receipt/v1"
+    assert receipt["accepted"] is False
+    assert "canonical_identity" in receipt["failed_gates"]
+
+
+def test_qazpipe_mode_never_hides_failure_with_local_fallback(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES", json.dumps({"geohazards": "qazpipe"})
+    )
+    monkeypatch.setattr(feed, "_items_by_family", dict)
+    with feed._lock:
+        feed._state.update({"entities": {}, "stale": True, "watermark": None})
+
+    result = feed.apply_layer_source_modes(
+        {"earthquakes": [{"id": "old-local"}]}, endpoint="slow"
+    )
+
+    assert result["earthquakes"] == []
+    assert result["qazpipe_state"]["status"] == "stale"
+    assert result["qazpipe_state"]["available"] is False
+
+
+def test_projection_filters_storage_and_provider_fields() -> None:
+    result = feed._public_item(
+        {
+            "entity_id": "quake-1",
+            "provider_id": "internal-provider",
+            "source_id": "internal-source",
+            "collection_receipt_id": "receipt-1",
+            "payload_hash_sha256": "a" * 64,
+            "properties": {
+                "layer_family": "geohazards",
+                "layer_key": "earthquakes",
+                "magnitude": 4.2,
+                "raw_payload": {"secret": True},
+                "source_url": "https://internal.invalid/source",
+            },
+            "latitude": 43.2,
+            "longitude": 76.9,
+            "observed_at": "2026-08-28T00:00:00Z",
+        }
+    )
+
+    assert result["id"] == "quake-1"
+    assert result["mag"] == 4.2
+    assert result["lat"] == 43.2
+    assert result["lng"] == 76.9
+    assert {
+        "provider_id",
+        "source_id",
+        "collection_receipt_id",
+        "payload_hash_sha256",
+        "raw_payload",
+        "source_url",
+    }.isdisjoint(result)

--- a/backend/tests/test_qazlake_shadow_schedule_cutover.py
+++ b/backend/tests/test_qazlake_shadow_schedule_cutover.py
@@ -1,0 +1,44 @@
+import json
+
+from services import data_fetcher
+
+
+def _named(name):
+    def collector():
+        return None
+
+    collector.__name__ = name
+    return collector
+
+
+def test_public_collectors_run_in_compare_and_stop_in_qazpipe(monkeypatch) -> None:
+    flight = _named("fetch_flights")
+    train = _named("fetch_trains")
+    ships = _named("fetch_ships")
+    monkeypatch.setenv(
+        "SHADOW_LAYER_SOURCE_MODES",
+        json.dumps(
+            {
+                "aviation_public": "compare",
+                "transport_public": "qazpipe",
+            }
+        ),
+    )
+
+    assert data_fetcher._eligible_collectors([flight, train, ships]) == [
+        flight,
+        ships,
+    ]
+
+
+def test_operator_and_derived_jobs_are_not_public_collection_families() -> None:
+    retained = [
+        _named("fetch_ships"),
+        _named("fetch_sigint"),
+        _named("fetch_sar_products"),
+        _named("fetch_unusual_whales"),
+        _named("prune_stale_vessels"),
+        _named("oracle_sweep"),
+    ]
+
+    assert data_fetcher._eligible_collectors(retained) == retained

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,5 +1,5 @@
 # Lean local backend for live DM E2E — Infonet swarm + wormhole without OSINT fetchers.
-# Pair with docker-compose.override.yml (local build + fleet secrets).
+# Pair with docker-compose.override.yml (local build + operator-provided secrets).
 services:
   backend:
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,10 +22,10 @@ services:
       MESH_DEFAULT_SYNC_PEERS: ""
       MESH_BOOTSTRAP_SIGNER_PUBLIC_KEY: "ul1d0kj/ODPIp0OhHzX8eLAVXzJ3CVvzW1vn2IC6q3I="
       MESH_SWARM_MANIFEST_PULL_INTERVAL_S: "300"
-      # Fleet testnet HMAC — overrides stale per-node .env so announce/push auth matches seed.
-      MESH_PEER_PUSH_SECRET: "b7GoqsvoUD9MV7tyt0ZOzMptLA84QG6KCfaV9nDqz5Y"
-      # Dev fleet: allow wormhole child agent to start without release attestation.
-      PRIVACY_CORE_DEV_OVERRIDE: "true"
+      # Credentials are operator-managed. PREVIOUS is receive-only during a
+      # rolling rotation and must be cleared once every node uses the primary.
+      MESH_PEER_PUSH_SECRET: "${MESH_PEER_PUSH_SECRET:-}"
+      MESH_PEER_PUSH_SECRET_PREVIOUS: "${MESH_PEER_PUSH_SECRET_PREVIOUS:-}"
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       - MESH_PUBLIC_PEER_URL=${MESH_PUBLIC_PEER_URL:-}
       # Shared transport auth for operator peer push. Must be set to a unique secret per deployment.
       - MESH_PEER_PUSH_SECRET=${MESH_PEER_PUSH_SECRET:-}
+      # Receive-only fallback for rolling rotation. Clear after all peers use primary.
+      - MESH_PEER_PUSH_SECRET_PREVIOUS=${MESH_PEER_PUSH_SECRET_PREVIOUS:-}
       # Issue #256: optional per-peer HMAC secrets. Comma-separated
       # `url=secret` pairs (no spaces). When a peer URL appears here, only
       # the listed per-peer secret is accepted for it — the global
@@ -131,6 +133,15 @@ services:
       # instead — the UI persists OPENCLAW_HMAC_SECRET to data/openclaw.env on the
       # backend_data volume so host-side agents can HMAC-auth after container restarts.
       - OPENCLAW_HMAC_SECRET=${OPENCLAW_HMAC_SECRET:-}
+      # Protected QazLake consumer feed. Keep modes empty until a family has
+      # passed compare receipts; production should inject the token by file.
+      - QAZLAKE_SHADOW_FEED_URL=${QAZLAKE_SHADOW_FEED_URL:-}
+      - QAZLAKE_SHADOW_FEED_TOKEN_FILE=${QAZLAKE_SHADOW_FEED_TOKEN_FILE:-}
+      - SHADOW_LAYER_SOURCE_MODES=${SHADOW_LAYER_SOURCE_MODES:-}
+      - SHADOW_LAYER_FAMILY_KEYS=${SHADOW_LAYER_FAMILY_KEYS:-}
+      - SHADOW_QAZLAKE_CACHE_PATH=${SHADOW_QAZLAKE_CACHE_PATH:-/app/data/qazlake_shadow_cache.json}
+      - SHADOW_QAZPIPE_COMPARE_RECEIPT_PATH=${SHADOW_QAZPIPE_COMPARE_RECEIPT_PATH:-/app/data/qazpipe_compare_receipts.jsonl}
+      - QAZLAKE_SHADOW_POLL_INTERVAL_S=${QAZLAKE_SHADOW_POLL_INTERVAL_S:-30}
     volumes:
       - backend_data:/app/data
     restart: unless-stopped

--- a/scripts/start-dm-test-nodes.ps1
+++ b/scripts/start-dm-test-nodes.ps1
@@ -108,7 +108,8 @@ function Write-NodeRunner(
   [string]$BackendDir,
   [string]$Python,
   [int]$Port,
-  [int]$PeerPort
+  [int]$PeerPort,
+  [string]$PeerPushSecret
 ) {
   $nodeRoot = Split-Path $BackendDir -Parent
   $logPath = Join-Path $nodeRoot "backend-$Port.log"
@@ -127,7 +128,7 @@ set SB_TEST_NODE_NAME=$NodeName
 set SB_TEST_NODE_URL=http://127.0.0.1:$Port
 set ADMIN_KEY=dm-test-node-local-admin-key-00000001
 set MESH_SELF_PEER_URL=http://127.0.0.1:$Port
-set MESH_PEER_PUSH_SECRET=dm-test-two-node-peer-push-secret-00000001
+set MESH_PEER_PUSH_SECRET=$PeerPushSecret
 set MESH_ONLY=true
 set MESH_NODE_MODE=participant
 set MESH_BOOTSTRAP_DISABLED=true
@@ -147,10 +148,16 @@ cd /d "$BackendDir"
   return @{ Runner = $runner; Log = $logPath }
 }
 
-function Start-TestNode([string]$NodeName, [int]$Port, [int]$PeerPort, [string]$Python) {
+function Start-TestNode(
+  [string]$NodeName,
+  [int]$Port,
+  [int]$PeerPort,
+  [string]$Python,
+  [string]$PeerPushSecret
+) {
   Stop-PortIfListening $Port
   $backendDir = Sync-RuntimeBackend $NodeName
-  $runnerInfo = Write-NodeRunner $NodeName $backendDir $Python $Port $PeerPort
+  $runnerInfo = Write-NodeRunner $NodeName $backendDir $Python $Port $PeerPort $PeerPushSecret
   $cmd = "/c `"`"$($runnerInfo.Runner)`" > `"$($runnerInfo.Log)`" 2>&1`""
   $process = Start-Process -FilePath "cmd.exe" -ArgumentList $cmd -PassThru -WindowStyle Minimized
   return @{
@@ -166,10 +173,18 @@ function Start-TestNode([string]$NodeName, [int]$Port, [int]$PeerPort, [string]$
 
 New-Item -ItemType Directory -Force -Path $RuntimeRoot | Out-Null
 $python = Resolve-SharedPython
+$peerSecretBytes = New-Object byte[] 32
+$peerSecretGenerator = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+try {
+  $peerSecretGenerator.GetBytes($peerSecretBytes)
+} finally {
+  $peerSecretGenerator.Dispose()
+}
+$peerPushSecret = [Convert]::ToBase64String($peerSecretBytes)
 
 $nodes = @(
-  Start-TestNode "node-a" $NodeAPort $NodeBPort $python
-  Start-TestNode "node-b" $NodeBPort $NodeAPort $python
+  Start-TestNode "node-a" $NodeAPort $NodeBPort $python $peerPushSecret
+  Start-TestNode "node-b" $NodeBPort $NodeAPort $python $peerPushSecret
 )
 
 $payload = @{


### PR DESCRIPTION
## Scope
This is the first narrow, incremental slice extracted from the closed broad convergence PR. It adds one backend service and focused tests only.

- no router, startup, compose, schedule, frontend, or deployment wiring
- default behavior is unchanged because an empty/missing `SHADOW_LAYER_SOURCE_MODES` returns the original payload by identity
- supports explicit `compare` receipts and opt-in `qazpipe` projection for later integration PRs
- `compare` preserves the current public response
- `qazpipe` never silently falls back to local data and exposes stale state
- strips provider IDs, receipts, raw payloads, URLs, credentials, and topology from public projections

## Validation
- `PYTHONPATH=backend python -m pytest -q backend/tests/test_qazlake_shadow_feed_client.py` (5 passed)
- `python -m ruff format --check ...`
- `python -m ruff check ...`
- `python -m compileall -q backend/services/qazlake_shadow_feed.py`
- `git diff --check`